### PR TITLE
Implement REST API surface per api-contract.md

### DIFF
--- a/app/Http/Controllers/Api/Admin/AccountingExportController.php
+++ b/app/Http/Controllers/Api/Admin/AccountingExportController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Domain\Audit\Audit;
+use App\Http\Controllers\ApiController;
+use App\Models\AccountingExport;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AccountingExportController extends ApiController
+{
+    public function index(): JsonResponse
+    {
+        $exports = AccountingExport::orderBy('requested_at', 'desc')->get();
+
+        return $this->success($exports->map(fn ($e) => [
+            'accountingExportId' => $e->id,
+            'exportType'         => $e->export_type,
+            'fileFormat'         => $e->file_format,
+            'exportStatus'       => $e->export_status,
+            'requestedAt'        => $e->requested_at?->toIso8601String(),
+        ])->all());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'serviceSessionId' => ['nullable', 'exists:service_sessions,id'],
+            'exportType'       => ['required', 'string', 'in:ACCOUNTING_SUMMARY'],
+            'fileFormat'       => ['required', 'string', 'in:CSV,JSON'],
+        ]);
+
+        $export = AccountingExport::create([
+            'venue_id'           => \App\Models\Venue::first()?->id,
+            'service_session_id' => $validated['serviceSessionId'] ?? null,
+            'export_type'        => $validated['exportType'],
+            'file_format'        => $validated['fileFormat'],
+            'export_status'      => 'REQUESTED',
+            'requested_by_user_id' => $request->user()->id,
+            'requested_at'       => now(),
+        ]);
+
+        Audit::record(
+            'EXPORT_REQUESTED',
+            "Exportação #{$export->id} solicitada",
+            ['type' => $export->export_type, 'format' => $export->file_format],
+            ['accounting_export_id' => $export->id],
+        );
+
+        return $this->success([
+            'accountingExportId' => $export->id,
+            'exportStatus'       => $export->export_status,
+        ], status: 201);
+    }
+
+    public function show(AccountingExport $accountingExport): JsonResponse
+    {
+        return $this->success([
+            'accountingExportId' => $accountingExport->id,
+            'exportType'         => $accountingExport->export_type,
+            'fileFormat'         => $accountingExport->file_format,
+            'exportStatus'       => $accountingExport->export_status,
+            'fileName'           => $accountingExport->file_name,
+            'requestedAt'        => $accountingExport->requested_at?->toIso8601String(),
+            'completedAt'        => $accountingExport->completed_at?->toIso8601String(),
+        ]);
+    }
+
+    public function download(AccountingExport $accountingExport): JsonResponse
+    {
+        if (! $accountingExport->file_name || $accountingExport->export_status !== 'COMPLETED') {
+            return $this->error('NOT_FOUND', 'Export file not ready.', status: 404);
+        }
+
+        // MVP placeholder: in real implementation this would stream the file.
+        return $this->error('NOT_FOUND', 'Export download not yet implemented.', status: 404);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/BillingStatusController.php
+++ b/app/Http/Controllers/Api/Admin/BillingStatusController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\ApiController;
+use App\Models\BillingStatus;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class BillingStatusController extends ApiController
+{
+    public function index(): JsonResponse
+    {
+        $statuses = BillingStatus::where('is_active', true)
+            ->orderBy('sort_order')
+            ->get();
+
+        return $this->success($statuses->map(fn ($s) => [
+            'billingStatusId' => $s->id,
+            'code'            => $s->code,
+            'displayName'     => $s->display_name,
+            'sortOrder'       => $s->sort_order,
+            'isActive'        => $s->is_active,
+        ])->all());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'code'        => ['required', 'string', 'max:50', 'unique:billing_statuses,code'],
+            'displayName' => ['required', 'string', 'max:100'],
+            'sortOrder'   => ['nullable', 'integer'],
+        ]);
+
+        $status = BillingStatus::create([
+            'code'        => $validated['code'],
+            'display_name'=> $validated['displayName'],
+            'sort_order'  => $validated['sortOrder'] ?? 0,
+            'is_active'   => true,
+        ]);
+
+        return $this->success([
+            'billingStatusId' => $status->id,
+            'code'            => $status->code,
+            'displayName'     => $status->display_name,
+        ], status: 201);
+    }
+
+    public function update(Request $request, BillingStatus $billingStatus): JsonResponse
+    {
+        $validated = $request->validate([
+            'displayName' => ['nullable', 'string', 'max:100'],
+            'sortOrder'   => ['nullable', 'integer'],
+            'isActive'    => ['nullable', 'boolean'],
+        ]);
+
+        $update = [];
+        if (array_key_exists('displayName', $validated)) $update['display_name'] = $validated['displayName'];
+        if (array_key_exists('sortOrder', $validated))   $update['sort_order'] = $validated['sortOrder'];
+        if (array_key_exists('isActive', $validated))    $update['is_active'] = $validated['isActive'];
+
+        $billingStatus->update($update);
+
+        return $this->success([
+            'billingStatusId' => $billingStatus->id,
+            'code'            => $billingStatus->code,
+            'displayName'     => $billingStatus->display_name,
+            'isActive'        => $billingStatus->is_active,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/MenuCategoryController.php
+++ b/app/Http/Controllers/Api/Admin/MenuCategoryController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\ApiController;
+use App\Models\MenuCategory;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class MenuCategoryController extends ApiController
+{
+    public function index(): JsonResponse
+    {
+        $categories = MenuCategory::where('is_active', true)
+            ->orderBy('sort_order')
+            ->get();
+
+        return $this->success($categories->map(fn ($c) => [
+            'menuCategoryId' => $c->id,
+            'code'           => $c->code,
+            'displayName'    => $c->display_name,
+            'routeType'      => $c->route_type,
+            'sortOrder'      => $c->sort_order,
+        ])->all());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'code'        => ['required', 'string', 'max:50', 'unique:menu_categories,code'],
+            'displayName' => ['required', 'string', 'max:100'],
+            'routeType'   => ['required', 'string', 'in:KITCHEN,BAR,NONE'],
+            'sortOrder'   => ['nullable', 'integer'],
+        ]);
+
+        $category = MenuCategory::create([
+            'code'         => $validated['code'],
+            'display_name' => $validated['displayName'],
+            'route_type'   => $validated['routeType'],
+            'sort_order'   => $validated['sortOrder'] ?? 0,
+            'is_active'    => true,
+        ]);
+
+        return $this->success([
+            'menuCategoryId' => $category->id,
+            'code'           => $category->code,
+            'displayName'    => $category->display_name,
+        ], status: 201);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/MenuItemController.php
+++ b/app/Http/Controllers/Api/Admin/MenuItemController.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\ApiController;
+use App\Models\MenuItem;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class MenuItemController extends ApiController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $query = MenuItem::with('category')
+            ->where('is_active', true)
+            ->orderBy('display_name');
+
+        if ($request->filled('categoryId')) {
+            $query->where('menu_category_id', $request->input('categoryId'));
+        }
+
+        return $this->success($query->get()->map(fn ($item) => [
+            'menuItemId'     => $item->id,
+            'menuCategoryId' => $item->menu_category_id,
+            'categoryName'   => $item->category?->display_name,
+            'sku'            => $item->sku,
+            'code'           => $item->code,
+            'displayName'    => $item->display_name,
+            'shortName'      => $item->short_name,
+            'unitPrice'      => (string) $item->unit_price,
+            'isActive'       => $item->is_active,
+        ])->all());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'menuCategoryId' => ['required', 'exists:menu_categories,id'],
+            'displayName'    => ['required', 'string', 'max:100'],
+            'shortName'      => ['nullable', 'string', 'max:50'],
+            'sku'            => ['nullable', 'string', 'max:50'],
+            'code'           => ['nullable', 'string', 'max:50'],
+            'unitPrice'      => ['required', 'numeric', 'min:0'],
+            'taxCode'        => ['nullable', 'string', 'max:20'],
+        ]);
+
+        $item = MenuItem::create([
+            'menu_category_id' => $validated['menuCategoryId'],
+            'display_name'     => $validated['displayName'],
+            'short_name'       => $validated['shortName'] ?? null,
+            'sku'              => $validated['sku'] ?? null,
+            'code'             => $validated['code'] ?? null,
+            'unit_price'       => $validated['unitPrice'],
+            'tax_code'         => $validated['taxCode'] ?? null,
+            'is_active'        => true,
+        ]);
+
+        return $this->success([
+            'menuItemId'  => $item->id,
+            'displayName' => $item->display_name,
+            'unitPrice'   => (string) $item->unit_price,
+        ], status: 201);
+    }
+
+    public function update(Request $request, MenuItem $menuItem): JsonResponse
+    {
+        $validated = $request->validate([
+            'menuCategoryId' => ['nullable', 'exists:menu_categories,id'],
+            'displayName'    => ['nullable', 'string', 'max:100'],
+            'shortName'      => ['nullable', 'string', 'max:50'],
+            'sku'            => ['nullable', 'string', 'max:50'],
+            'code'           => ['nullable', 'string', 'max:50'],
+            'unitPrice'      => ['nullable', 'numeric', 'min:0'],
+            'taxCode'        => ['nullable', 'string', 'max:20'],
+            'isActive'       => ['nullable', 'boolean'],
+        ]);
+
+        $update = [];
+        if (array_key_exists('menuCategoryId', $validated)) $update['menu_category_id'] = $validated['menuCategoryId'];
+        if (array_key_exists('displayName', $validated))    $update['display_name'] = $validated['displayName'];
+        if (array_key_exists('shortName', $validated))      $update['short_name'] = $validated['shortName'];
+        if (array_key_exists('sku', $validated))            $update['sku'] = $validated['sku'];
+        if (array_key_exists('code', $validated))           $update['code'] = $validated['code'];
+        if (array_key_exists('unitPrice', $validated))      $update['unit_price'] = $validated['unitPrice'];
+        if (array_key_exists('taxCode', $validated))        $update['tax_code'] = $validated['taxCode'];
+        if (array_key_exists('isActive', $validated))       $update['is_active'] = $validated['isActive'];
+
+        $menuItem->update($update);
+
+        return $this->success([
+            'menuItemId'  => $menuItem->id,
+            'displayName' => $menuItem->display_name,
+            'unitPrice'   => (string) $menuItem->unit_price,
+            'isActive'    => $menuItem->is_active,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/PrinterController.php
+++ b/app/Http/Controllers/Api/Admin/PrinterController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\ApiController;
+use App\Models\Printer;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PrinterController extends ApiController
+{
+    public function index(): JsonResponse
+    {
+        $printers = Printer::orderBy('name')->get();
+
+        return $this->success($printers->map(fn ($p) => [
+            'printerId'       => $p->id,
+            'name'            => $p->name,
+            'printerType'     => $p->printer_type,
+            'connectionType'  => $p->connection_type,
+            'address'         => $p->address,
+            'port'            => $p->port,
+            'isActive'        => $p->is_active,
+            'healthStatus'    => $p->health_status,
+        ])->all());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name'           => ['required', 'string', 'max:100'],
+            'printerType'    => ['required', 'string', 'in:KITCHEN,BAR,BILL,GENERIC'],
+            'connectionType' => ['required', 'string', 'in:LAN,USB_AGENT,NULL'],
+            'address'        => ['nullable', 'string', 'max:255'],
+            'port'           => ['nullable', 'integer'],
+        ]);
+
+        $printer = Printer::create([
+            'name'            => $validated['name'],
+            'printer_type'    => $validated['printerType'],
+            'connection_type' => $validated['connectionType'],
+            'address'         => $validated['address'] ?? null,
+            'port'            => $validated['port'] ?? null,
+            'is_active'       => true,
+            'health_status'   => 'UNKNOWN',
+        ]);
+
+        return $this->success([
+            'printerId' => $printer->id,
+            'name'      => $printer->name,
+        ], status: 201);
+    }
+
+    public function update(Request $request, Printer $printer): JsonResponse
+    {
+        $validated = $request->validate([
+            'name'           => ['nullable', 'string', 'max:100'],
+            'printerType'    => ['nullable', 'string', 'in:KITCHEN,BAR,BILL,GENERIC'],
+            'connectionType' => ['nullable', 'string', 'in:LAN,USB_AGENT,NULL'],
+            'address'        => ['nullable', 'string', 'max:255'],
+            'port'           => ['nullable', 'integer'],
+            'isActive'       => ['nullable', 'boolean'],
+        ]);
+
+        $update = [];
+        if (array_key_exists('name', $validated))           $update['name'] = $validated['name'];
+        if (array_key_exists('printerType', $validated))    $update['printer_type'] = $validated['printerType'];
+        if (array_key_exists('connectionType', $validated)) $update['connection_type'] = $validated['connectionType'];
+        if (array_key_exists('address', $validated))        $update['address'] = $validated['address'];
+        if (array_key_exists('port', $validated))           $update['port'] = $validated['port'];
+        if (array_key_exists('isActive', $validated))       $update['is_active'] = $validated['isActive'];
+
+        $printer->update($update);
+
+        return $this->success([
+            'printerId' => $printer->id,
+            'name'      => $printer->name,
+            'isActive'  => $printer->is_active,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/PrinterRouteController.php
+++ b/app/Http/Controllers/Api/Admin/PrinterRouteController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\ApiController;
+use App\Models\PrinterRoute;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PrinterRouteController extends ApiController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $query = PrinterRoute::with(['printer', 'venue']);
+
+        if ($request->filled('venueId')) {
+            $query->where('venue_id', $request->input('venueId'));
+        }
+
+        $routes = $query->get();
+
+        return $this->success($routes->map(fn ($r) => [
+            'printerRouteId'   => $r->id,
+            'venueId'          => $r->venue_id,
+            'documentType'     => $r->document_type,
+            'fulfillmentRoute' => $r->fulfillment_route,
+            'printerId'        => $r->printer_id,
+            'printerName'      => $r->printer?->name,
+            'isActive'         => $r->is_active,
+        ])->all());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'venueId'           => ['required', 'exists:venues,id'],
+            'documentType'      => ['required', 'string', 'in:PRODUCTION_TICKET,BILL,VOID_SLIP'],
+            'fulfillmentRoute'  => ['nullable', 'string', 'in:KITCHEN,BAR,NONE'],
+            'printerId'         => ['required', 'exists:printers,id'],
+        ]);
+
+        $route = PrinterRoute::updateOrCreate(
+            [
+                'venue_id'          => $validated['venueId'],
+                'document_type'     => $validated['documentType'],
+                'fulfillment_route' => $validated['fulfillmentRoute'] ?? null,
+            ],
+            [
+                'printer_id' => $validated['printerId'],
+                'is_active'  => true,
+            ]
+        );
+
+        return $this->success([
+            'printerRouteId'   => $route->id,
+            'documentType'     => $route->document_type,
+            'fulfillmentRoute' => $route->fulfillment_route,
+        ], status: 201);
+    }
+
+    public function update(Request $request, PrinterRoute $printerRoute): JsonResponse
+    {
+        $validated = $request->validate([
+            'printerId'  => ['nullable', 'exists:printers,id'],
+            'isActive'   => ['nullable', 'boolean'],
+        ]);
+
+        $update = [];
+        if (array_key_exists('printerId', $validated)) $update['printer_id'] = $validated['printerId'];
+        if (array_key_exists('isActive', $validated))  $update['is_active'] = $validated['isActive'];
+
+        $printerRoute->update($update);
+
+        return $this->success([
+            'printerRouteId'   => $printerRoute->id,
+            'documentType'     => $printerRoute->document_type,
+            'printerId'        => $printerRoute->printer_id,
+            'isActive'         => $printerRoute->is_active,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/RoleController.php
+++ b/app/Http/Controllers/Api/Admin/RoleController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\ApiController;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Spatie\Permission\Models\Role;
+
+class RoleController extends ApiController
+{
+    public function index(): JsonResponse
+    {
+        $roles = Role::all();
+
+        return $this->success($roles->map(fn ($r) => [
+            'roleId'   => $r->id,
+            'name'     => $r->name,
+        ])->all());
+    }
+
+    public function assign(Request $request, User $user): JsonResponse
+    {
+        $validated = $request->validate([
+            'role' => ['required', 'string', 'exists:roles,name'],
+        ]);
+
+        $role = Role::findByName($validated['role']);
+        $user->assignRole($role);
+
+        return $this->success([
+            'userId' => $user->id,
+            'roles'  => $user->roles->pluck('name')->values()->all(),
+        ]);
+    }
+
+    public function updateAssignment(Request $request, User $user, Role $role): JsonResponse
+    {
+        $validated = $request->validate([
+            'role' => ['required', 'string', 'exists:roles,name'],
+        ]);
+
+        $user->removeRole($role);
+        $user->assignRole($validated['role']);
+
+        return $this->success([
+            'userId' => $user->id,
+            'roles'  => $user->roles->pluck('name')->values()->all(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/RowController.php
+++ b/app/Http/Controllers/Api/Admin/RowController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\ApiController;
+use App\Models\Row;
+use App\Models\Section;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class RowController extends ApiController
+{
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'sectionId' => ['required', 'exists:sections,id'],
+            'rowCode'   => ['required', 'string', 'max:10'],
+            'sortOrder' => ['nullable', 'integer'],
+        ]);
+
+        $row = Row::create([
+            'section_id' => $validated['sectionId'],
+            'row_code'   => $validated['rowCode'],
+            'sort_order' => $validated['sortOrder'] ?? 0,
+            'is_active'  => true,
+        ]);
+
+        return $this->success([
+            'rowId'   => $row->id,
+            'rowCode' => $row->row_code,
+        ], status: 201);
+    }
+
+    public function update(Request $request, Row $row): JsonResponse
+    {
+        $validated = $request->validate([
+            'rowCode'   => ['nullable', 'string', 'max:10'],
+            'sortOrder' => ['nullable', 'integer'],
+            'isActive'  => ['nullable', 'boolean'],
+        ]);
+
+        $update = [];
+        if (array_key_exists('rowCode', $validated))  $update['row_code'] = $validated['rowCode'];
+        if (array_key_exists('sortOrder', $validated)) $update['sort_order'] = $validated['sortOrder'];
+        if (array_key_exists('isActive', $validated))  $update['is_active'] = $validated['isActive'];
+
+        $row->update($update);
+
+        return $this->success([
+            'rowId'   => $row->id,
+            'rowCode' => $row->row_code,
+            'isActive'=> $row->is_active,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/SeatController.php
+++ b/app/Http/Controllers/Api/Admin/SeatController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\ApiController;
+use App\Models\Row;
+use App\Models\Seat;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SeatController extends ApiController
+{
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'rowId'      => ['required', 'exists:rows,id'],
+            'seatNumber' => ['required', 'integer', 'min:1'],
+            'sortOrder'  => ['nullable', 'integer'],
+        ]);
+
+        $seat = Seat::create([
+            'row_id'      => $validated['rowId'],
+            'seat_number' => $validated['seatNumber'],
+            'sort_order'  => $validated['sortOrder'] ?? $validated['seatNumber'],
+            'is_active'   => true,
+        ]);
+
+        return $this->success([
+            'seatId'     => $seat->id,
+            'seatNumber' => $seat->seat_number,
+        ], status: 201);
+    }
+
+    public function update(Request $request, Seat $seat): JsonResponse
+    {
+        $validated = $request->validate([
+            'seatNumber' => ['nullable', 'integer', 'min:1'],
+            'sortOrder'  => ['nullable', 'integer'],
+            'isActive'   => ['nullable', 'boolean'],
+        ]);
+
+        $update = [];
+        if (array_key_exists('seatNumber', $validated)) $update['seat_number'] = $validated['seatNumber'];
+        if (array_key_exists('sortOrder', $validated))  $update['sort_order'] = $validated['sortOrder'];
+        if (array_key_exists('isActive', $validated))   $update['is_active'] = $validated['isActive'];
+
+        $seat->update($update);
+
+        return $this->success([
+            'seatId'     => $seat->id,
+            'seatNumber' => $seat->seat_number,
+            'isActive'   => $seat->is_active,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/SeatPairController.php
+++ b/app/Http/Controllers/Api/Admin/SeatPairController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\ApiController;
+use App\Models\Row;
+use App\Models\SeatPair;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SeatPairController extends ApiController
+{
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'rowId'        => ['required', 'exists:rows,id'],
+            'pairSequence' => ['required', 'integer', 'min:1'],
+            'seatAId'      => ['required', 'exists:seats,id'],
+            'seatBId'      => ['required', 'exists:seats,id'],
+        ]);
+
+        $pair = SeatPair::create([
+            'row_id'        => $validated['rowId'],
+            'pair_sequence' => $validated['pairSequence'],
+            'seat_a_id'     => $validated['seatAId'],
+            'seat_b_id'     => $validated['seatBId'],
+            'is_active'     => true,
+        ]);
+
+        return $this->success([
+            'seatPairId'   => $pair->id,
+            'pairSequence' => $pair->pair_sequence,
+        ], status: 201);
+    }
+
+    public function update(Request $request, SeatPair $seatPair): JsonResponse
+    {
+        $validated = $request->validate([
+            'pairSequence' => ['nullable', 'integer', 'min:1'],
+            'seatAId'      => ['nullable', 'exists:seats,id'],
+            'seatBId'      => ['nullable', 'exists:seats,id'],
+            'isActive'     => ['nullable', 'boolean'],
+        ]);
+
+        $update = [];
+        if (array_key_exists('pairSequence', $validated)) $update['pair_sequence'] = $validated['pairSequence'];
+        if (array_key_exists('seatAId', $validated))      $update['seat_a_id'] = $validated['seatAId'];
+        if (array_key_exists('seatBId', $validated))      $update['seat_b_id'] = $validated['seatBId'];
+        if (array_key_exists('isActive', $validated))     $update['is_active'] = $validated['isActive'];
+
+        $seatPair->update($update);
+
+        return $this->success([
+            'seatPairId'   => $seatPair->id,
+            'pairSequence' => $seatPair->pair_sequence,
+            'isActive'     => $seatPair->is_active,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/SectionController.php
+++ b/app/Http/Controllers/Api/Admin/SectionController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\ApiController;
+use App\Models\Section;
+use App\Models\Venue;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SectionController extends ApiController
+{
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'venueId'     => ['required', 'exists:venues,id'],
+            'sectionCode' => ['required', 'string', 'max:10'],
+            'name'        => ['required', 'string', 'max:100'],
+            'sortOrder'   => ['nullable', 'integer'],
+        ]);
+
+        $section = Section::create([
+            'venue_id'     => $validated['venueId'],
+            'section_code' => $validated['sectionCode'],
+            'name'         => $validated['name'],
+            'sort_order'   => $validated['sortOrder'] ?? 0,
+            'is_active'    => true,
+        ]);
+
+        return $this->success([
+            'sectionId'   => $section->id,
+            'sectionCode' => $section->section_code,
+            'name'        => $section->name,
+        ], status: 201);
+    }
+
+    public function update(Request $request, Section $section): JsonResponse
+    {
+        $validated = $request->validate([
+            'sectionCode' => ['nullable', 'string', 'max:10'],
+            'name'        => ['nullable', 'string', 'max:100'],
+            'sortOrder'   => ['nullable', 'integer'],
+            'isActive'    => ['nullable', 'boolean'],
+        ]);
+
+        $update = [];
+        if (array_key_exists('sectionCode', $validated)) $update['section_code'] = $validated['sectionCode'];
+        if (array_key_exists('name', $validated))        $update['name'] = $validated['name'];
+        if (array_key_exists('sortOrder', $validated))   $update['sort_order'] = $validated['sortOrder'];
+        if (array_key_exists('isActive', $validated))    $update['is_active'] = $validated['isActive'];
+
+        $section->update($update);
+
+        return $this->success([
+            'sectionId'   => $section->id,
+            'sectionCode' => $section->section_code,
+            'name'        => $section->name,
+            'isActive'    => $section->is_active,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/TranslationController.php
+++ b/app/Http/Controllers/Api/Admin/TranslationController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\ApiController;
+use App\Models\TranslationKey;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class TranslationController extends ApiController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'languageCode' => ['required', 'string', 'max:10'],
+        ]);
+
+        $translations = TranslationKey::where('language_code', $validated['languageCode'])
+            ->where('is_active', true)
+            ->get();
+
+        $grouped = $translations->groupBy('translation_namespace');
+
+        $data = [];
+        foreach ($grouped as $namespace => $items) {
+            $data[$namespace] = $items->mapWithKeys(fn ($t) => [
+                $t->translation_key => $t->translation_value,
+            ])->all();
+        }
+
+        return $this->success([
+            'languageCode' => $validated['languageCode'],
+            'translations' => $data,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/UserController.php
+++ b/app/Http/Controllers/Api/Admin/UserController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\ApiController;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+
+class UserController extends ApiController
+{
+    public function index(): JsonResponse
+    {
+        $users = User::with('roles')->orderBy('name')->get();
+
+        return $this->success($users->map(fn ($u) => [
+            'userId'            => $u->id,
+            'username'          => $u->username,
+            'displayName'       => $u->name,
+            'email'             => $u->email,
+            'preferredLanguage' => $u->preferred_language_code,
+            'isActive'          => $u->is_active,
+            'roles'             => $u->roles->pluck('name')->values()->all(),
+        ])->all());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'username'          => ['required', 'string', 'max:50', 'unique:users,username'],
+            'displayName'       => ['required', 'string', 'max:100'],
+            'email'             => ['required', 'email', 'max:255', 'unique:users,email'],
+            'password'          => ['required', 'string', 'min:6'],
+            'preferredLanguage' => ['nullable', 'string', 'max:10'],
+        ]);
+
+        $user = User::create([
+            'username'                => $validated['username'],
+            'name'                    => $validated['displayName'],
+            'email'                   => $validated['email'],
+            'password'                => Hash::make($validated['password']),
+            'preferred_language_code' => $validated['preferredLanguage'] ?? 'pt-PT',
+            'is_active'               => true,
+        ]);
+
+        return $this->success([
+            'userId'      => $user->id,
+            'username'    => $user->username,
+            'displayName' => $user->name,
+        ], status: 201);
+    }
+
+    public function update(Request $request, User $user): JsonResponse
+    {
+        $validated = $request->validate([
+            'displayName'       => ['nullable', 'string', 'max:100'],
+            'email'             => ['nullable', 'email', 'max:255'],
+            'preferredLanguage' => ['nullable', 'string', 'max:10'],
+            'isActive'          => ['nullable', 'boolean'],
+        ]);
+
+        $update = [];
+        if (array_key_exists('displayName', $validated))       $update['name'] = $validated['displayName'];
+        if (array_key_exists('email', $validated))             $update['email'] = $validated['email'];
+        if (array_key_exists('preferredLanguage', $validated)) $update['preferred_language_code'] = $validated['preferredLanguage'];
+        if (array_key_exists('isActive', $validated))          $update['is_active'] = $validated['isActive'];
+
+        $user->update($update);
+
+        return $this->success([
+            'userId'      => $user->id,
+            'username'    => $user->username,
+            'displayName' => $user->name,
+            'isActive'    => $user->is_active,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/VenueController.php
+++ b/app/Http/Controllers/Api/Admin/VenueController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\ApiController;
+use App\Models\Venue;
+use Illuminate\Http\JsonResponse;
+
+class VenueController extends ApiController
+{
+    public function show(Venue $venue): JsonResponse
+    {
+        return $this->success([
+            'venueId'   => $venue->id,
+            'venueCode' => $venue->venue_code,
+            'name'      => $venue->name,
+            'isActive'  => $venue->is_active,
+        ]);
+    }
+
+    public function layout(Venue $venue): JsonResponse
+    {
+        $venue->load(['sections.rows.seatPairs']);
+
+        return $this->success([
+            'venueId'   => $venue->id,
+            'sections'  => $venue->sections->map(fn ($section) => [
+                'sectionId'   => $section->id,
+                'sectionCode' => $section->section_code,
+                'name'        => $section->name,
+                'rows'        => $section->rows->map(fn ($row) => [
+                    'rowId'   => $row->id,
+                    'rowCode' => $row->row_code,
+                    'seatPairs' => $row->seatPairs->map(fn ($pair) => [
+                        'seatPairId'   => $pair->id,
+                        'pairSequence' => $pair->pair_sequence,
+                    ])->values()->all(),
+                ])->values()->all(),
+            ])->values()->all(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\ApiController;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+class AuthController extends ApiController
+{
+    public function login(Request $request): JsonResponse
+    {
+        $request->validate([
+            'username' => ['required', 'string'],
+            'password' => ['required', 'string'],
+            'language' => ['nullable', 'string'],
+        ]);
+
+        $user = User::where('username', $request->input('username'))->first();
+
+        if (! $user || ! Hash::check($request->input('password'), $user->password)) {
+            return $this->error('UNAUTHENTICATED', 'Invalid credentials.', status: 401);
+        }
+
+        if (! $user->is_active) {
+            return $this->error('FORBIDDEN', 'Account is inactive.', status: 403);
+        }
+
+        Auth::login($user);
+
+        if ($request->filled('language')) {
+            $user->update(['preferred_language_code' => $request->input('language')]);
+        }
+
+        $user->update(['last_login_at' => now()]);
+
+        return $this->success([
+            'user' => [
+                'id'                => $user->id,
+                'displayName'       => $user->name,
+                'roles'             => $user->roles->pluck('name')->values()->all(),
+                'preferredLanguage' => $user->preferred_language_code,
+            ],
+            'session' => [
+                'token'     => $request->session()->getId(),
+                'expiresAt' => now()->addHours(12)->toIso8601String(),
+            ],
+        ]);
+    }
+
+    public function logout(Request $request): JsonResponse
+    {
+        Auth::logout();
+        $request->session()->invalidate();
+
+        return $this->success();
+    }
+
+    public function me(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        return $this->success([
+            'id'                => $user->id,
+            'displayName'       => $user->name,
+            'roles'             => $user->roles->pluck('name')->values()->all(),
+            'preferredLanguage' => $user->preferred_language_code,
+            'permissions'       => $user->permissions->pluck('name')->values()->all(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/BillingDocumentController.php
+++ b/app/Http/Controllers/Api/BillingDocumentController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Domain\Billing\BillingService;
+use App\Http\Controllers\ApiController;
+use App\Models\BillingDocument;
+use App\Models\BillingGroup;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class BillingDocumentController extends ApiController
+{
+    public function __construct(private readonly BillingService $billingService) {}
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'billingGroupId' => ['required', 'exists:billing_groups,id'],
+            'documentType'   => ['required', 'string', 'in:INTERNAL_BILL'],
+            'print'          => ['nullable', 'boolean'],
+        ]);
+
+        $group = BillingGroup::findOrFail($validated['billingGroupId']);
+
+        if ($group->is_closed) {
+            return $this->error('GROUP_CLOSED', 'Cannot generate bill for a closed group.', status: 409);
+        }
+
+        try {
+            $bill = $this->billingService->generateInternalBill($group, $request->user());
+        } catch (\RuntimeException $e) {
+            if (str_contains($e->getMessage(), 'cashier printer')) {
+                return $this->error('PRINTER_ROUTE_MISSING', $e->getMessage(), status: 422);
+            }
+            return $this->error('VALIDATION_ERROR', $e->getMessage(), status: 400);
+        }
+
+        return $this->success([
+            'billingDocumentId' => $bill->id,
+            'documentType'      => $bill->document_type,
+            'documentStatus'    => $bill->document_status,
+            'totalAmount'       => (string) $bill->total_amount,
+        ], status: 201);
+    }
+
+    public function reprint(Request $request, BillingDocument $billingDocument): JsonResponse
+    {
+        $request->validate([
+            'reason' => ['nullable', 'string', 'max:500'],
+        ]);
+
+        try {
+            $reprint = $this->billingService->reprintBill($billingDocument, $request->user());
+        } catch (\RuntimeException $e) {
+            if (str_contains($e->getMessage(), 'cashier printer')) {
+                return $this->error('PRINTER_ROUTE_MISSING', $e->getMessage(), status: 422);
+            }
+            return $this->error('PRINT_FAILED', $e->getMessage(), status: 500);
+        }
+
+        return $this->success([
+            'billingDocumentId' => $reprint->id,
+            'documentType'      => $reprint->document_type,
+            'documentStatus'    => $reprint->document_status,
+            'totalAmount'       => (string) $reprint->total_amount,
+            'isReprint'         => true,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/BillingGroupController.php
+++ b/app/Http/Controllers/Api/BillingGroupController.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Domain\Floor\BillingGroupService;
+use App\Domain\Floor\OccupancyService;
+use App\Domain\Floor\ZoneOverlapException;
+use App\Http\Controllers\ApiController;
+use App\Models\BillingGroup;
+use App\Models\BillingStatus;
+use App\Models\Row;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class BillingGroupController extends ApiController
+{
+    public function __construct(
+        private readonly BillingGroupService $billingGroupService,
+        private readonly OccupancyService $occupancyService,
+    ) {}
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'statusCode' => ['required', 'string', 'exists:billing_statuses,code'],
+            'coverCount' => ['nullable', 'integer', 'min:1'],
+            'notes'      => ['nullable', 'string', 'max:500'],
+            'zones'      => ['nullable', 'array'],
+            'zones.*.rowId'                   => ['required', 'exists:rows,id'],
+            'zones.*.startSeatPairSequence'   => ['required', 'integer', 'min:1'],
+            'zones.*.endSeatPairSequence'     => ['required', 'integer', 'min:1'],
+            'zones.*.deliveryMode'            => ['nullable', 'string', 'in:CENTER,SPECIFIC_SEAT_PAIR'],
+        ]);
+
+        $session = \App\Models\ServiceSession::where('status', 'OPEN')
+            ->orderBy('starts_at', 'desc')
+            ->first();
+
+        if (! $session) {
+            return $this->error('NOT_FOUND', 'No active service session found.', status: 404);
+        }
+
+        try {
+            $group = DB::transaction(function () use ($request, $validated, $session) {
+                $group = $this->billingGroupService->open(
+                    $session,
+                    $request->user(),
+                    $validated['coverCount'] ?? null,
+                    $validated['notes'] ?? null,
+                );
+
+                // Apply initial status if not ACTIVE
+                if (($validated['statusCode'] ?? 'ACTIVE') !== 'ACTIVE') {
+                    $this->billingGroupService->setStatus($group, $validated['statusCode'], $request->user());
+                    $group->refresh();
+                }
+
+                // Create zones if provided
+                if (! empty($validated['zones'])) {
+                    foreach ($validated['zones'] as $zoneData) {
+                        $row = Row::findOrFail($zoneData['rowId']);
+                        $this->occupancyService->assignZone(
+                            $group,
+                            $row,
+                            (int) $zoneData['startSeatPairSequence'],
+                            (int) $zoneData['endSeatPairSequence'],
+                            $request->user(),
+                            $zoneData['deliveryCenterLabel'] ?? null,
+                        );
+                    }
+                    $group->load('occupiedZones');
+                }
+
+                return $group;
+            });
+        } catch (ZoneOverlapException $e) {
+            return $this->error('ZONE_OVERLAP', $e->getMessage(), status: 409);
+        } catch (\RuntimeException $e) {
+            return $this->error('VALIDATION_ERROR', $e->getMessage(), status: 400);
+        }
+
+        return $this->success($this->toBillingGroupDto($group), status: 201);
+    }
+
+    public function show(BillingGroup $billingGroup): JsonResponse
+    {
+        $billingGroup->load(['occupiedZones.row', 'status', 'orderHeaders.items', 'billingDocuments', 'paymentRecords']);
+
+        return $this->success($this->toBillingGroupDto($billingGroup, detailed: true));
+    }
+
+    public function update(Request $request, BillingGroup $billingGroup): JsonResponse
+    {
+        $validated = $request->validate([
+            'versionNumber' => ['nullable', 'integer'],
+            'statusCode'    => ['nullable', 'string', 'exists:billing_statuses,code'],
+            'coverCount'    => ['nullable', 'integer', 'min:1'],
+            'notes'         => ['nullable', 'string', 'max:500'],
+        ]);
+
+        if (isset($validated['versionNumber']) && $billingGroup->version_number !== $validated['versionNumber']) {
+            return $this->error('VERSION_CONFLICT', 'Billing group was modified by another user.', status: 409);
+        }
+
+        if ($billingGroup->is_closed && ! empty($validated)) {
+            return $this->error('GROUP_CLOSED', 'Cannot modify a closed billing group.', status: 409);
+        }
+
+        try {
+            DB::transaction(function () use ($request, $billingGroup, $validated) {
+                if (! empty($validated['statusCode'])) {
+                    $this->billingGroupService->setStatus($billingGroup, $validated['statusCode'], $request->user());
+                }
+
+                $update = [];
+                if (array_key_exists('coverCount', $validated)) {
+                    $update['cover_count'] = $validated['coverCount'];
+                }
+                if (array_key_exists('notes', $validated)) {
+                    $update['notes'] = $validated['notes'];
+                }
+                if (! empty($update)) {
+                    $billingGroup->update($update);
+                }
+
+                $billingGroup->increment('version_number');
+            });
+        } catch (\RuntimeException $e) {
+            return $this->error('INVALID_STATUS_TRANSITION', $e->getMessage(), status: 409);
+        }
+
+        return $this->success($this->toBillingGroupDto($billingGroup->refresh()));
+    }
+
+    public function storeZones(Request $request, BillingGroup $billingGroup): JsonResponse
+    {
+        $validated = $request->validate([
+            'zones' => ['required', 'array', 'min:1'],
+            'zones.*.rowId'                   => ['required', 'exists:rows,id'],
+            'zones.*.startSeatPairSequence'   => ['required', 'integer', 'min:1'],
+            'zones.*.endSeatPairSequence'     => ['required', 'integer', 'min:1'],
+            'zones.*.deliveryMode'            => ['nullable', 'string', 'in:CENTER,SPECIFIC_SEAT_PAIR'],
+        ]);
+
+        if ($billingGroup->is_closed) {
+            return $this->error('GROUP_CLOSED', 'Cannot assign zones to a closed billing group.', status: 409);
+        }
+
+        try {
+            DB::transaction(function () use ($request, $billingGroup, $validated) {
+                foreach ($validated['zones'] as $zoneData) {
+                    $row = Row::findOrFail($zoneData['rowId']);
+                    $this->occupancyService->assignZone(
+                        $billingGroup,
+                        $row,
+                        (int) $zoneData['startSeatPairSequence'],
+                        (int) $zoneData['endSeatPairSequence'],
+                        $request->user(),
+                        $zoneData['deliveryCenterLabel'] ?? null,
+                    );
+                }
+            });
+        } catch (ZoneOverlapException $e) {
+            return $this->error('ZONE_OVERLAP', $e->getMessage(), status: 409);
+        } catch (\RuntimeException $e) {
+            return $this->error('VALIDATION_ERROR', $e->getMessage(), status: 400);
+        }
+
+        return $this->success($this->toBillingGroupDto($billingGroup->refresh()->load('occupiedZones')));
+    }
+
+    public function orders(BillingGroup $billingGroup): JsonResponse
+    {
+        $orders = $billingGroup->orderHeaders()
+            ->with(['items.menuItem', 'occupiedZone', 'orderedBy'])
+            ->orderBy('ordered_at')
+            ->get();
+
+        return $this->success($orders->map(fn ($o) => $this->toOrderDto($o))->all());
+    }
+
+    public function productionTickets(BillingGroup $billingGroup): JsonResponse
+    {
+        $tickets = $billingGroup->productionTickets()
+            ->with(['printer', 'items'])
+            ->orderBy('requested_at', 'desc')
+            ->get();
+
+        return $this->success($tickets->map(fn ($t) => [
+            'productionTicketId' => $t->id,
+            'ticketType'         => $t->ticket_type,
+            'ticketStatus'       => $t->ticket_status,
+            'billingGroupId'     => $t->billing_group_id,
+            'occupiedZoneId'     => $t->occupied_zone_id,
+            'printerId'          => $t->printer_id,
+            'printedAt'          => $t->printed_at?->toIso8601String(),
+            'isVoidSlip'         => $t->is_void_slip,
+            'isReprint'          => $t->is_reprint,
+        ])->all());
+    }
+
+    public function billSummary(BillingGroup $billingGroup): JsonResponse
+    {
+        $billingGroup->load(['occupiedZones.row', 'orderHeaders.items.menuItem', 'paymentRecords']);
+
+        $lines = $billingGroup->orderHeaders
+            ->flatMap->items
+            ->whereNull('voided_at')
+            ->map(fn ($item) => [
+                'orderItemId'   => $item->id,
+                'menuItemName'  => $item->menuItem?->display_name,
+                'quantity'      => $item->quantity,
+                'unitPrice'     => (string) $item->unit_price,
+                'lineSubtotal'  => (string) $item->line_subtotal,
+            ])->values()->all();
+
+        $charges = $billingGroup->chargesTotal();
+        $payments = $billingGroup->paymentsTotal();
+
+        return $this->success([
+            'billingGroupId' => $billingGroup->id,
+            'displayCode'    => $billingGroup->display_code,
+            'statusCode'     => $billingGroup->status?->code,
+            'zones'          => $billingGroup->occupiedZones->map(fn ($z) => [
+                'occupiedZoneId' => $z->id,
+                'rowCode'        => $z->row?->row_code,
+                'startSeatPairSequence' => $z->start_seat_pair_sequence,
+                'endSeatPairSequence'   => $z->end_seat_pair_sequence,
+            ])->all(),
+            'lineItems'      => $lines,
+            'subtotal'       => (string) $charges,
+            'total'          => (string) $charges,
+            'paymentsToDate' => $billingGroup->paymentRecords->where('is_voided', false)->map(fn ($p) => [
+                'paymentRecordId' => $p->id,
+                'amount'          => (string) $p->amount,
+                'paymentLabel'    => $p->payment_label,
+                'recordedAt'      => $p->recorded_at?->toIso8601String(),
+            ])->values()->all(),
+            'remainingBalance' => (string) max(0, round($charges - $payments, 2)),
+        ]);
+    }
+
+    public function reopen(Request $request, BillingGroup $billingGroup): JsonResponse
+    {
+        $request->validate([
+            'reason' => ['nullable', 'string', 'max:500'],
+        ]);
+
+        if (! $billingGroup->is_closed) {
+            return $this->error('CONFLICT', 'Billing group is already open.', status: 409);
+        }
+
+        $this->billingGroupService->reopen($billingGroup, $request->user());
+
+        return $this->success($this->toBillingGroupDto($billingGroup->refresh()));
+    }
+
+    private function toBillingGroupDto(BillingGroup $group, bool $detailed = false): array
+    {
+        $dto = [
+            'billingGroupId' => $group->id,
+            'displayCode'    => $group->display_code,
+            'statusCode'     => $group->status?->code,
+            'statusLabel'    => $group->status?->display_name,
+            'coverCount'     => $group->cover_count,
+            'isClosed'       => $group->is_closed,
+            'versionNumber'  => $group->version_number,
+            'openedAt'       => $group->opened_at?->toIso8601String(),
+            'closedAt'       => $group->closed_at?->toIso8601String(),
+            'zones'          => $group->occupiedZones->map(fn ($z) => [
+                'occupiedZoneId'         => $z->id,
+                'rowId'                  => $z->row_id,
+                'rowCode'                => $z->row?->row_code,
+                'startSeatPairSequence'  => $z->start_seat_pair_sequence,
+                'endSeatPairSequence'    => $z->end_seat_pair_sequence,
+                'defaultDeliveryReference' => $z->defaultDeliveryLabel(),
+                'deliverySeatPairId'     => $z->delivery_seat_pair_id,
+                'isOpen'                 => $z->is_open,
+            ])->values()->all(),
+        ];
+
+        if ($detailed) {
+            $dto['runningTotals'] = [
+                'charges'  => (string) $group->chargesTotal(),
+                'payments' => (string) $group->paymentsTotal(),
+                'balance'  => (string) $group->balance(),
+            ];
+            $dto['recentDocuments'] = $group->billingDocuments->sortByDesc('requested_at')->take(5)->map(fn ($d) => [
+                'billingDocumentId' => $d->id,
+                'documentType'      => $d->document_type,
+                'documentStatus'    => $d->document_status,
+                'totalAmount'       => (string) $d->total_amount,
+                'printedAt'         => $d->printed_at?->toIso8601String(),
+                'isReprint'         => $d->is_reprint,
+            ])->values()->all();
+        }
+
+        return $dto;
+    }
+
+    private function toOrderDto(\App\Models\OrderHeader $order): array
+    {
+        return [
+            'orderHeaderId'     => $order->id,
+            'billingGroupId'    => $order->billing_group_id,
+            'occupiedZoneId'    => $order->occupied_zone_id,
+            'orderedBy'         => [
+                'userId'      => $order->ordered_by_user_id,
+                'displayName' => $order->orderedBy?->name,
+            ],
+            'orderedAt'         => $order->ordered_at?->toIso8601String(),
+            'submissionStatus'  => $order->submission_status,
+            'notes'             => $order->notes,
+            'items'             => $order->items->map(fn ($item) => [
+                'orderItemId'          => $item->id,
+                'menuItemId'           => $item->menu_item_id,
+                'menuItemName'         => $item->menuItem?->display_name,
+                'quantity'             => $item->quantity,
+                'unitPrice'            => (string) $item->unit_price,
+                'lineSubtotal'         => (string) $item->line_subtotal,
+                'fulfillmentRoute'     => $item->fulfillment_route,
+                'deliverySeatPairId'   => $item->delivery_seat_pair_id,
+                'deliveryReferenceLabel' => $item->delivery_reference_label,
+                'voidedAt'             => $item->voided_at?->toIso8601String(),
+                'voidReason'           => $item->void_reason,
+            ])->values()->all(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/EventLogController.php
+++ b/app/Http/Controllers/Api/EventLogController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\ApiController;
+use App\Models\AuditEvent;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class EventLogController extends ApiController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'serviceSessionId' => ['nullable', 'integer', 'exists:service_sessions,id'],
+            'billingGroupId'   => ['nullable', 'integer', 'exists:billing_groups,id'],
+            'eventType'        => ['nullable', 'string'],
+            'from'             => ['nullable', 'date'],
+            'to'               => ['nullable', 'date'],
+            'page'             => ['nullable', 'integer', 'min:1'],
+            'pageSize'         => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        $query = AuditEvent::with('actor')
+            ->orderBy('event_time', 'desc');
+
+        if (! empty($validated['serviceSessionId'])) {
+            $query->where('service_session_id', $validated['serviceSessionId']);
+        }
+        if (! empty($validated['billingGroupId'])) {
+            $query->where('billing_group_id', $validated['billingGroupId']);
+        }
+        if (! empty($validated['eventType'])) {
+            $query->where('event_type', $validated['eventType']);
+        }
+        if (! empty($validated['from'])) {
+            $query->whereDate('event_time', '>=', $validated['from']);
+        }
+        if (! empty($validated['to'])) {
+            $query->whereDate('event_time', '<=', $validated['to']);
+        }
+
+        $pageSize = $validated['pageSize'] ?? 25;
+        $page = $validated['page'] ?? 1;
+
+        $paginator = $query->paginate($pageSize, ['*'], 'page', $page);
+
+        $data = $paginator->map(fn ($event) => [
+            'eventId'          => $event->id,
+            'eventType'        => $event->event_type,
+            'eventTime'        => $event->event_time?->toIso8601String(),
+            'actor'            => $event->actor ? [
+                'userId'      => $event->actor->id,
+                'displayName' => $event->actor->name,
+            ] : null,
+            'billingGroupId'   => $event->billing_group_id,
+            'occupiedZoneId'   => $event->occupied_zone_id,
+            'summary'          => $event->summary,
+        ])->all();
+
+        return $this->success($data, [
+            'currentPage' => $paginator->currentPage(),
+            'lastPage'    => $paginator->lastPage(),
+            'perPage'     => $paginator->perPage(),
+            'total'       => $paginator->total(),
+        ]);
+    }
+
+    public function show(AuditEvent $auditEvent): JsonResponse
+    {
+        $auditEvent->load('actor');
+
+        return $this->success([
+            'eventId'          => $auditEvent->id,
+            'eventType'        => $auditEvent->event_type,
+            'eventTime'        => $auditEvent->event_time?->toIso8601String(),
+            'actor'            => $auditEvent->actor ? [
+                'userId'      => $auditEvent->actor->id,
+                'displayName' => $auditEvent->actor->name,
+            ] : null,
+            'billingGroupId'   => $auditEvent->billing_group_id,
+            'occupiedZoneId'   => $auditEvent->occupied_zone_id,
+            'orderHeaderId'    => $auditEvent->order_header_id,
+            'orderItemId'      => $auditEvent->order_item_id,
+            'productionTicketId'  => $auditEvent->production_ticket_id,
+            'billingDocumentId'   => $auditEvent->billing_document_id,
+            'paymentRecordId'     => $auditEvent->payment_record_id,
+            'summary'          => $auditEvent->summary,
+            'payload'          => $auditEvent->payload_json,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/FloorController.php
+++ b/app/Http/Controllers/Api/FloorController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\ApiController;
+use App\Models\OccupiedZone;
+use App\Models\Section;
+use App\Models\ServiceSession;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class FloorController extends ApiController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $session = ServiceSession::where('status', 'OPEN')
+            ->orderBy('starts_at', 'desc')
+            ->first();
+
+        if (! $session) {
+            return $this->error('NOT_FOUND', 'No active service session found.', status: 404);
+        }
+
+        $query = Section::with(['rows.seatPairs'])
+            ->where('is_active', true);
+
+        if ($request->filled('sectionId')) {
+            $query->where('id', $request->input('sectionId'));
+        }
+
+        $sections = $query->orderBy('sort_order')->get();
+        $includeClosed = filter_var($request->input('includeClosed', false), FILTER_VALIDATE_BOOLEAN);
+
+        // Preload open zones for the session
+        $zones = OccupiedZone::with(['billingGroup.status'])
+            ->whereHas('billingGroup', fn ($q) => $q->where('service_session_id', $session->id))
+            ->when(! $includeClosed, fn ($q) => $q->where('is_open', true))
+            ->get();
+
+        $groupedZones = $zones->groupBy(fn ($z) => $z->row_id);
+
+        $result = $sections->map(function ($section) use ($groupedZones) {
+            return [
+                'sectionId'   => $section->id,
+                'sectionCode' => $section->section_code,
+                'rows'        => $section->rows->map(function ($row) use ($groupedZones) {
+                    $rowZones = $groupedZones->get($row->id, collect());
+
+                    return [
+                        'rowId'   => $row->id,
+                        'rowCode' => $row->row_code,
+                        'seatPairs' => $row->seatPairs->map(function ($pair) use ($rowZones) {
+                            $zone = $rowZones->first(function ($z) use ($pair) {
+                                return $pair->pair_sequence >= $z->start_seat_pair_sequence
+                                    && $pair->pair_sequence <= $z->end_seat_pair_sequence;
+                            });
+
+                            $data = [
+                                'pairSequence' => $pair->pair_sequence,
+                                'state'        => $zone ? 'OCCUPIED' : 'FREE',
+                            ];
+
+                            if ($zone) {
+                                $data['billingGroupId'] = $zone->billing_group_id;
+                                $data['status'] = $zone->billingGroup?->status?->code;
+                            }
+
+                            return $data;
+                        })->values()->all(),
+                    ];
+                })->values()->all(),
+            ];
+        })->values()->all();
+
+        return $this->success([
+            'sessionId' => $session->id,
+            'sections'  => $result,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/OccupiedZoneController.php
+++ b/app/Http/Controllers/Api/OccupiedZoneController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Domain\Floor\OccupancyService;
+use App\Http\Controllers\ApiController;
+use App\Models\OccupiedZone;
+use App\Models\SeatPair;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class OccupiedZoneController extends ApiController
+{
+    public function __construct(private readonly OccupancyService $occupancyService) {}
+
+    public function show(OccupiedZone $occupiedZone): JsonResponse
+    {
+        $occupiedZone->load(['billingGroup', 'row', 'deliverySeatPair']);
+
+        return $this->success([
+            'occupiedZoneId'         => $occupiedZone->id,
+            'billingGroupId'         => $occupiedZone->billing_group_id,
+            'rowId'                  => $occupiedZone->row_id,
+            'rowCode'                => $occupiedZone->row?->row_code,
+            'startSeatPairSequence'  => $occupiedZone->start_seat_pair_sequence,
+            'endSeatPairSequence'    => $occupiedZone->end_seat_pair_sequence,
+            'defaultDeliveryReference' => $occupiedZone->defaultDeliveryLabel(),
+            'deliverySeatPairId'     => $occupiedZone->delivery_seat_pair_id,
+            'isOpen'                 => $occupiedZone->is_open,
+            'openedAt'               => $occupiedZone->opened_at?->toIso8601String(),
+            'releasedAt'             => $occupiedZone->released_at?->toIso8601String(),
+        ]);
+    }
+
+    public function update(Request $request, OccupiedZone $occupiedZone): JsonResponse
+    {
+        $validated = $request->validate([
+            'deliveryMode'       => ['nullable', 'string', 'in:CENTER,SPECIFIC_SEAT_PAIR'],
+            'deliverySeatPairId' => ['nullable', 'exists:seat_pairs,id'],
+            'releasedAt'         => ['nullable', 'date'],
+            'isOpen'             => ['nullable', 'boolean'],
+        ]);
+
+        $update = [];
+
+        if (array_key_exists('deliveryMode', $validated)) {
+            $update['default_delivery_mode'] = $validated['deliveryMode'];
+        }
+
+        if (array_key_exists('deliverySeatPairId', $validated)) {
+            if ($validated['deliverySeatPairId']) {
+                $pair = SeatPair::find($validated['deliverySeatPairId']);
+                if ($pair->row_id !== $occupiedZone->row_id) {
+                    return $this->error('INVALID_DELIVERY_TARGET', 'Delivery seat pair must be in the same row.', status: 400);
+                }
+                if ($pair->pair_sequence < $occupiedZone->start_seat_pair_sequence
+                    || $pair->pair_sequence > $occupiedZone->end_seat_pair_sequence) {
+                    return $this->error('INVALID_DELIVERY_TARGET', 'Delivery seat pair must fall inside the zone range.', status: 400);
+                }
+            }
+            $update['delivery_seat_pair_id'] = $validated['deliverySeatPairId'];
+        }
+
+        if (array_key_exists('releasedAt', $validated) || array_key_exists('isOpen', $validated)) {
+            if (($validated['isOpen'] ?? true) === false || $validated['releasedAt']) {
+                $this->occupancyService->releaseZone($occupiedZone, $request->user());
+                return $this->success([
+                    'occupiedZoneId' => $occupiedZone->refresh()->id,
+                    'isOpen'         => $occupiedZone->is_open,
+                    'releasedAt'     => $occupiedZone->released_at?->toIso8601String(),
+                ]);
+            }
+        }
+
+        if (! empty($update)) {
+            $occupiedZone->update($update);
+        }
+
+        return $this->success([
+            'occupiedZoneId'         => $occupiedZone->refresh()->id,
+            'defaultDeliveryReference' => $occupiedZone->defaultDeliveryLabel(),
+            'deliverySeatPairId'     => $occupiedZone->delivery_seat_pair_id,
+            'isOpen'                 => $occupiedZone->is_open,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Domain\Orders\OrderService;
+use App\Http\Controllers\ApiController;
+use App\Models\BillingGroup;
+use App\Models\OccupiedZone;
+use App\Models\OrderHeader;
+use App\Models\OrderItem;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class OrderController extends ApiController
+{
+    public function __construct(private readonly OrderService $orderService) {}
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'billingGroupId'   => ['required', 'exists:billing_groups,id'],
+            'occupiedZoneId'   => ['nullable', 'exists:occupied_zones,id'],
+            'notes'            => ['nullable', 'string', 'max:500'],
+            'items'            => ['required', 'array', 'min:1'],
+            'items.*.menuItemId'          => ['required', 'exists:menu_items,id'],
+            'items.*.quantity'            => ['required', 'integer', 'min:1'],
+            'items.*.deliverySeatPairId'  => ['nullable', 'exists:seat_pairs,id'],
+        ]);
+
+        $group = BillingGroup::findOrFail($validated['billingGroupId']);
+
+        if ($group->is_closed) {
+            return $this->error('GROUP_CLOSED', 'Cannot create orders for a closed billing group.', status: 409);
+        }
+
+        $zone = null;
+        if (! empty($validated['occupiedZoneId'])) {
+            $zone = OccupiedZone::find($validated['occupiedZoneId']);
+            if ($zone && $zone->billing_group_id !== $group->id) {
+                return $this->error('INVALID_DELIVERY_TARGET', 'Occupied zone does not belong to this billing group.', status: 400);
+            }
+        }
+
+        $lines = collect($validated['items'])->map(fn ($item) => [
+            'menu_item_id'          => $item['menuItemId'],
+            'quantity'              => $item['quantity'],
+            'delivery_seat_pair_id' => $item['deliverySeatPairId'] ?? null,
+        ])->all();
+
+        try {
+            $header = $this->orderService->submit(
+                $group,
+                $request->user(),
+                $lines,
+                $zone,
+                $validated['notes'] ?? null,
+            );
+        } catch (\RuntimeException $e) {
+            return $this->error('VALIDATION_ERROR', $e->getMessage(), status: 400);
+        }
+
+        return $this->success($this->toOrderDto($header->refresh()->load('items.menuItem')), status: 201);
+    }
+
+    public function show(OrderHeader $orderHeader): JsonResponse
+    {
+        $orderHeader->load(['items.menuItem', 'billingGroup', 'occupiedZone', 'orderedBy']);
+
+        return $this->success($this->toOrderDto($orderHeader));
+    }
+
+    public function voidItems(Request $request, OrderHeader $orderHeader): JsonResponse
+    {
+        $validated = $request->validate([
+            'items' => ['required', 'array', 'min:1'],
+            'items.*.orderItemId' => ['required', 'exists:order_items,id'],
+            'items.*.reason'      => ['required', 'string', 'max:500'],
+        ]);
+
+        if ($orderHeader->billingGroup->is_closed) {
+            return $this->error('GROUP_CLOSED', 'Cannot void items on a closed billing group.', status: 409);
+        }
+
+        $affected = [];
+        $tickets = [];
+
+        DB::transaction(function () use ($request, $orderHeader, $validated, &$affected, &$tickets) {
+            foreach ($validated['items'] as $itemData) {
+                $item = OrderItem::where('order_header_id', $orderHeader->id)
+                    ->where('id', $itemData['orderItemId'])
+                    ->first();
+
+                if (! $item) {
+                    continue;
+                }
+
+                $this->orderService->voidItem($item, $request->user(), $itemData['reason']);
+                $affected[] = $item->refresh();
+            }
+
+            // Load any void tickets created
+            $tickets = $orderHeader->billingGroup->productionTickets()
+                ->where('is_void_slip', true)
+                ->where('created_at', '>=', now()->subSeconds(5))
+                ->get();
+        });
+
+        return $this->success([
+            'affectedItems' => collect($affected)->map(fn ($item) => [
+                'orderItemId' => $item->id,
+                'voidedAt'    => $item->voided_at?->toIso8601String(),
+                'voidReason'  => $item->void_reason,
+            ])->all(),
+            'voidTickets' => $tickets->map(fn ($t) => [
+                'productionTicketId' => $t->id,
+                'ticketType'         => $t->ticket_type,
+                'isVoidSlip'         => $t->is_void_slip,
+            ])->all(),
+        ]);
+    }
+
+    private function toOrderDto(OrderHeader $order): array
+    {
+        return [
+            'orderHeaderId'     => $order->id,
+            'billingGroupId'    => $order->billing_group_id,
+            'occupiedZoneId'    => $order->occupied_zone_id,
+            'orderedBy'         => [
+                'userId'      => $order->ordered_by_user_id,
+                'displayName' => $order->orderedBy?->name,
+            ],
+            'orderedAt'         => $order->ordered_at?->toIso8601String(),
+            'submissionStatus'  => $order->submission_status,
+            'notes'             => $order->notes,
+            'items'             => $order->items->map(fn ($item) => [
+                'orderItemId'            => $item->id,
+                'menuItemId'             => $item->menu_item_id,
+                'menuItemName'           => $item->menuItem?->display_name,
+                'quantity'               => $item->quantity,
+                'unitPrice'              => (string) $item->unit_price,
+                'lineSubtotal'           => (string) $item->line_subtotal,
+                'fulfillmentRoute'       => $item->fulfillment_route,
+                'deliverySeatPairId'     => $item->delivery_seat_pair_id,
+                'deliveryReferenceLabel' => $item->delivery_reference_label,
+                'voidedAt'               => $item->voided_at?->toIso8601String(),
+                'voidReason'             => $item->void_reason,
+            ])->values()->all(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/PaymentController.php
+++ b/app/Http/Controllers/Api/PaymentController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Domain\Billing\BillingService;
+use App\Http\Controllers\ApiController;
+use App\Models\BillingGroup;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PaymentController extends ApiController
+{
+    public function __construct(private readonly BillingService $billingService) {}
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'billingGroupId' => ['required', 'exists:billing_groups,id'],
+            'amount'         => ['required', 'numeric', 'min:0.01'],
+            'paymentLabel'   => ['required', 'string', 'max:100'],
+            'notes'          => ['nullable', 'string', 'max:500'],
+        ]);
+
+        $group = BillingGroup::findOrFail($validated['billingGroupId']);
+
+        if ($group->is_closed) {
+            return $this->error('GROUP_CLOSED', 'Cannot record payment on a closed billing group.', status: 409);
+        }
+
+        try {
+            $payment = $this->billingService->recordPayment(
+                $group,
+                $request->user(),
+                (float) $validated['amount'],
+                $validated['paymentLabel'],
+                $validated['notes'] ?? null,
+            );
+        } catch (\RuntimeException $e) {
+            return $this->error('VALIDATION_ERROR', $e->getMessage(), status: 400);
+        }
+
+        return $this->success([
+            'paymentRecordId' => $payment->id,
+            'billingGroupId'  => $payment->billing_group_id,
+            'amount'          => (string) $payment->amount,
+            'paymentLabel'    => $payment->payment_label,
+            'recordedAt'      => $payment->recorded_at?->toIso8601String(),
+        ], status: 201);
+    }
+}

--- a/app/Http/Controllers/Api/ProductionTicketController.php
+++ b/app/Http/Controllers/Api/ProductionTicketController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Domain\Audit\Audit;
+use App\Domain\Printing\PrintQueueService;
+use App\Http\Controllers\ApiController;
+use App\Models\ProductionTicket;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class ProductionTicketController extends ApiController
+{
+    public function __construct(private readonly PrintQueueService $printQueue) {}
+
+    public function show(ProductionTicket $productionTicket): JsonResponse
+    {
+        $productionTicket->load(['items.menuItem', 'printer', 'billingGroup', 'occupiedZone']);
+
+        return $this->success([
+            'productionTicketId'     => $productionTicket->id,
+            'ticketType'             => $productionTicket->ticket_type,
+            'ticketStatus'           => $productionTicket->ticket_status,
+            'billingGroupId'         => $productionTicket->billing_group_id,
+            'occupiedZoneId'         => $productionTicket->occupied_zone_id,
+            'printerId'              => $productionTicket->printer_id,
+            'printerName'            => $productionTicket->printer?->name,
+            'printedAt'              => $productionTicket->printed_at?->toIso8601String(),
+            'requestedAt'            => $productionTicket->requested_at?->toIso8601String(),
+            'isVoidSlip'             => $productionTicket->is_void_slip,
+            'isReprint'              => $productionTicket->is_reprint,
+            'deliveryReferenceLabel' => $productionTicket->delivery_reference_label,
+            'items'                  => $productionTicket->items->map(fn ($item) => [
+                'orderItemId'   => $item->id,
+                'menuItemName'  => $item->menuItem?->display_name,
+                'quantity'      => $item->quantity,
+            ])->values()->all(),
+        ]);
+    }
+
+    public function reprint(Request $request, ProductionTicket $productionTicket): JsonResponse
+    {
+        $request->validate([
+            'reason' => ['nullable', 'string', 'max:500'],
+        ]);
+
+        $user = $request->user();
+
+        $reprint = DB::transaction(function () use ($productionTicket, $user) {
+            $newTicket = ProductionTicket::create([
+                'service_session_id'     => $productionTicket->service_session_id,
+                'billing_group_id'       => $productionTicket->billing_group_id,
+                'occupied_zone_id'       => $productionTicket->occupied_zone_id,
+                'printer_id'             => $productionTicket->printer_id,
+                'ticket_type'            => $productionTicket->ticket_type,
+                'ticket_status'          => 'PENDING',
+                'delivery_reference_label' => $productionTicket->delivery_reference_label,
+                'requested_at'           => now(),
+                'reprint_of_ticket_id'   => $productionTicket->id,
+                'is_void_slip'           => $productionTicket->is_void_slip,
+                'is_reprint'             => true,
+                'created_by_user_id'     => $user->id,
+            ]);
+
+            $newTicket->items()->sync($productionTicket->items->pluck('id'));
+
+            $this->printQueue->enqueueProductionTicket($newTicket, $user);
+
+            Audit::record(
+                'PRODUCTION_TICKET_REPRINTED',
+                "Reimpressão do ticket #{$productionTicket->id}",
+                ['original_ticket_id' => $productionTicket->id],
+                [
+                    'billing_group_id'     => $productionTicket->billing_group_id,
+                    'service_session_id'   => $productionTicket->service_session_id,
+                    'production_ticket_id' => $newTicket->id,
+                ],
+            );
+
+            return $newTicket;
+        });
+
+        return $this->success([
+            'productionTicketId' => $reprint->id,
+            'isReprint'          => true,
+            'reprintOfTicketId'  => $productionTicket->id,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/SessionController.php
+++ b/app/Http/Controllers/Api/SessionController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\ApiController;
+use App\Models\BillingStatus;
+use App\Models\ServiceSession;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SessionController extends ApiController
+{
+    public function current(Request $request): JsonResponse
+    {
+        $session = ServiceSession::with('venue')
+            ->where('status', 'OPEN')
+            ->orderBy('starts_at', 'desc')
+            ->first();
+
+        if (! $session) {
+            return $this->error('NOT_FOUND', 'No active service session found.', status: 404);
+        }
+
+        $statuses = BillingStatus::where('is_active', true)
+            ->orderBy('sort_order')
+            ->get(['id', 'code', 'display_name']);
+
+        return $this->success([
+            'sessionId'     => $session->id,
+            'sessionType'   => $session->session_type,
+            'sessionLabel'  => $session->session_label,
+            'startsAt'      => $session->starts_at?->toIso8601String(),
+            'venue'         => [
+                'venueId'   => $session->venue?->id,
+                'venueCode' => $session->venue?->venue_code,
+                'name'      => $session->venue?->name,
+            ],
+            'activeBillingStatuses' => $statuses->map(fn ($s) => [
+                'statusId'   => $s->id,
+                'code'       => $s->code,
+                'displayName'=> $s->display_name,
+            ]),
+            'effectiveLanguageOptions' => ['pt-PT', 'en-US'],
+        ]);
+    }
+}

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+abstract class ApiController extends Controller
+{
+    protected function success(mixed $data = null, array $meta = [], int $status = 200): JsonResponse
+    {
+        return response()->json([
+            'success' => true,
+            'data'    => $data,
+            'meta'    => $meta,
+        ], $status);
+    }
+
+    protected function error(string $code, string $message, mixed $details = null, int $status = 400): JsonResponse
+    {
+        $payload = [
+            'success' => false,
+            'error'   => [
+                'code'    => $code,
+                'message' => $message,
+            ],
+        ];
+
+        if ($details !== null) {
+            $payload['error']['details'] = $details;
+        }
+
+        return response()->json($payload, $status);
+    }
+
+    protected function envelopeFromException(\Throwable $e): JsonResponse
+    {
+        $code = match (true) {
+            $e instanceof \Illuminate\Auth\AuthenticationException => 'UNAUTHENTICATED',
+            $e instanceof \Illuminate\Database\Eloquent\ModelNotFoundException => 'NOT_FOUND',
+            $e instanceof \App\Domain\Floor\ZoneOverlapException => 'ZONE_OVERLAP',
+            default => 'VALIDATION_ERROR',
+        };
+
+        $status = match ($code) {
+            'UNAUTHENTICATED' => 401,
+            'NOT_FOUND'       => 404,
+            'FORBIDDEN'       => 403,
+            'CONFLICT'        => 409,
+            default           => 400,
+        };
+
+        return $this->error($code, $e->getMessage(), status: $status);
+    }
+}

--- a/app/Http/Middleware/ApiAuth.php
+++ b/app/Http/Middleware/ApiAuth.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ApiAuth
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! auth()->check()) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'UNAUTHENTICATED',
+                    'message' => 'Unauthenticated.',
+                ],
+            ], 401);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/RequireAnyRole.php
+++ b/app/Http/Middleware/RequireAnyRole.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequireAnyRole
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, string ...$roles): Response
+    {
+        if (! $request->user()?->hasAnyRole($roles)) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'FORBIDDEN',
+                    'message' => 'This action requires an authorized role.',
+                ],
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/RequirePermission.php
+++ b/app/Http/Middleware/RequirePermission.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequirePermission
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, string $permission): Response
+    {
+        if (! $request->user()?->hasPermissionTo($permission)) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'FORBIDDEN',
+                    'message' => 'You do not have permission to perform this action.',
+                ],
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,11 +7,23 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'api.auth'   => \App\Http\Middleware\ApiAuth::class,
+            'permission' => \App\Http\Middleware\RequirePermission::class,
+            'role'       => \App\Http\Middleware\RequireAnyRole::class,
+        ]);
+
+        // API routes need session support for cookie-based auth in MVP.
+        $middleware->api(prepend: [
+            \Illuminate\Session\Middleware\StartSession::class,
+            \Illuminate\Cookie\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,12 +22,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_CONNECTION" value="pgsql"/>
-        <env name="DB_HOST" value="127.0.0.1"/>
-        <env name="DB_PORT" value="5432"/>
-        <env name="DB_DATABASE" value="serveo_test"/>
-        <env name="DB_USERNAME" value="serveo"/>
-        <env name="DB_PASSWORD" value="serveo"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,169 @@
+<?php
+
+use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\BillingDocumentController;
+use App\Http\Controllers\Api\BillingGroupController;
+use App\Http\Controllers\Api\EventLogController;
+use App\Http\Controllers\Api\FloorController;
+use App\Http\Controllers\Api\OccupiedZoneController;
+use App\Http\Controllers\Api\OrderController;
+use App\Http\Controllers\Api\PaymentController;
+use App\Http\Controllers\Api\ProductionTicketController;
+use App\Http\Controllers\Api\SessionController;
+use App\Http\Controllers\Api\Admin\AccountingExportController;
+use App\Http\Controllers\Api\Admin\BillingStatusController;
+use App\Http\Controllers\Api\Admin\MenuCategoryController;
+use App\Http\Controllers\Api\Admin\MenuItemController;
+use App\Http\Controllers\Api\Admin\PrinterController;
+use App\Http\Controllers\Api\Admin\PrinterRouteController;
+use App\Http\Controllers\Api\Admin\RoleController;
+use App\Http\Controllers\Api\Admin\RowController;
+use App\Http\Controllers\Api\Admin\SeatController;
+use App\Http\Controllers\Api\Admin\SeatPairController;
+use App\Http\Controllers\Api\Admin\SectionController;
+use App\Http\Controllers\Api\Admin\TranslationController;
+use App\Http\Controllers\Api\Admin\UserController;
+use App\Http\Controllers\Api\Admin\VenueController;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| API Routes
+|--------------------------------------------------------------------------
+*/
+
+Route::prefix('v1')->group(function () {
+
+    // Authentication
+    Route::post('auth/login', [AuthController::class, 'login']);
+    Route::middleware('api.auth')->group(function () {
+        Route::post('auth/logout', [AuthController::class, 'logout']);
+        Route::get('auth/me', [AuthController::class, 'me']);
+    });
+
+    // Floor & Occupancy (requires auth)
+    Route::middleware('api.auth')->group(function () {
+        Route::get('sessions/current', [SessionController::class, 'current']);
+        Route::get('floor', [FloorController::class, 'index']);
+
+        // Billing Groups
+        Route::post('billing-groups', [BillingGroupController::class, 'store'])
+            ->middleware('permission:floor.open_billing_group');
+        Route::get('billing-groups/{billingGroup}', [BillingGroupController::class, 'show'])
+            ->middleware('permission:billing_group.view');
+        Route::patch('billing-groups/{billingGroup}', [BillingGroupController::class, 'update'])
+            ->middleware('permission:billing_group.set_status');
+        Route::post('billing-groups/{billingGroup}/zones', [BillingGroupController::class, 'storeZones'])
+            ->middleware('permission:floor.assign_zone');
+        Route::get('billing-groups/{billingGroup}/orders', [BillingGroupController::class, 'orders'])
+            ->middleware('permission:billing_group.view');
+        Route::get('billing-groups/{billingGroup}/production-tickets', [BillingGroupController::class, 'productionTickets'])
+            ->middleware('permission:production_ticket.view');
+        Route::get('billing-groups/{billingGroup}/bill-summary', [BillingGroupController::class, 'billSummary'])
+            ->middleware('permission:billing_group.view');
+        Route::post('billing-groups/{billingGroup}/reopen', [BillingGroupController::class, 'reopen'])
+            ->middleware('permission:billing_group.reopen');
+
+        // Occupied Zones
+        Route::patch('occupied-zones/{occupiedZone}', [OccupiedZoneController::class, 'update'])
+            ->middleware('permission:floor.release_zone');
+        Route::get('occupied-zones/{occupiedZone}', [OccupiedZoneController::class, 'show'])
+            ->middleware('permission:floor.view');
+
+        // Orders
+        Route::post('orders', [OrderController::class, 'store'])
+            ->middleware('permission:order.create');
+        Route::get('orders/{orderHeader}', [OrderController::class, 'show'])
+            ->middleware('permission:order.create');
+        Route::post('orders/{orderHeader}/void-items', [OrderController::class, 'voidItems'])
+            ->middleware('permission:order.void_item');
+
+        // Production Tickets
+        Route::get('production-tickets/{productionTicket}', [ProductionTicketController::class, 'show'])
+            ->middleware('permission:production_ticket.view');
+        Route::post('production-tickets/{productionTicket}/reprint', [ProductionTicketController::class, 'reprint'])
+            ->middleware('permission:production_ticket.reprint');
+
+        // Billing Documents
+        Route::post('billing-documents', [BillingDocumentController::class, 'store'])
+            ->middleware('permission:billing_document.create');
+        Route::post('billing-documents/{billingDocument}/reprint', [BillingDocumentController::class, 'reprint'])
+            ->middleware('permission:billing_document.reprint');
+
+        // Payments
+        Route::post('payments', [PaymentController::class, 'store'])
+            ->middleware('permission:payment.record');
+
+        // Event Log
+        Route::get('event-log', [EventLogController::class, 'index'])
+            ->middleware('permission:audit.view');
+        Route::get('event-log/{auditEvent}', [EventLogController::class, 'show'])
+            ->middleware('permission:audit.view');
+    });
+
+    // Admin Configuration (requires auth + admin permissions)
+    Route::middleware(['api.auth', 'role:ADMIN'])->prefix('admin')->group(function () {
+        // Venues
+        Route::get('venues/{venue}', [VenueController::class, 'show']);
+        Route::get('venues/{venue}/layout', [VenueController::class, 'layout']);
+
+        // Sections
+        Route::post('sections', [SectionController::class, 'store']);
+        Route::patch('sections/{section}', [SectionController::class, 'update']);
+
+        // Rows
+        Route::post('rows', [RowController::class, 'store']);
+        Route::patch('rows/{row}', [RowController::class, 'update']);
+
+        // Seats
+        Route::post('seats', [SeatController::class, 'store']);
+        Route::patch('seats/{seat}', [SeatController::class, 'update']);
+
+        // Seat Pairs
+        Route::post('seat-pairs', [SeatPairController::class, 'store']);
+        Route::patch('seat-pairs/{seatPair}', [SeatPairController::class, 'update']);
+
+        // Billing Statuses
+        Route::get('billing-statuses', [BillingStatusController::class, 'index']);
+        Route::post('billing-statuses', [BillingStatusController::class, 'store']);
+        Route::patch('billing-statuses/{billingStatus}', [BillingStatusController::class, 'update']);
+
+        // Menu Categories
+        Route::get('menu-categories', [MenuCategoryController::class, 'index']);
+        Route::post('menu-categories', [MenuCategoryController::class, 'store']);
+
+        // Menu Items
+        Route::get('menu-items', [MenuItemController::class, 'index']);
+        Route::post('menu-items', [MenuItemController::class, 'store']);
+        Route::patch('menu-items/{menuItem}', [MenuItemController::class, 'update']);
+
+        // Printers
+        Route::get('printers', [PrinterController::class, 'index']);
+        Route::post('printers', [PrinterController::class, 'store']);
+        Route::patch('printers/{printer}', [PrinterController::class, 'update']);
+
+        // Printer Routes
+        Route::get('printer-routes', [PrinterRouteController::class, 'index']);
+        Route::post('printer-routes', [PrinterRouteController::class, 'store']);
+        Route::patch('printer-routes/{printerRoute}', [PrinterRouteController::class, 'update']);
+
+        // Users
+        Route::get('users', [UserController::class, 'index']);
+        Route::post('users', [UserController::class, 'store']);
+        Route::patch('users/{user}', [UserController::class, 'update']);
+
+        // Roles
+        Route::get('roles', [RoleController::class, 'index']);
+        Route::post('users/{user}/roles', [RoleController::class, 'assign']);
+        Route::patch('users/{user}/roles/{role}', [RoleController::class, 'updateAssignment']);
+
+        // Translations
+        Route::get('translations', [TranslationController::class, 'index']);
+
+        // Accounting Exports
+        Route::get('accounting-exports', [AccountingExportController::class, 'index']);
+        Route::post('accounting-exports', [AccountingExportController::class, 'store']);
+        Route::get('accounting-exports/{accountingExport}', [AccountingExportController::class, 'show']);
+        Route::get('accounting-exports/{accountingExport}/download', [AccountingExportController::class, 'download']);
+    });
+});

--- a/tests/Feature/ApiAuthTest.php
+++ b/tests/Feature/ApiAuthTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Models\BillingStatus;
+use App\Models\MenuItem;
+use App\Models\Row;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+beforeEach(function () {
+    $this->session = bootScenario();
+});
+
+it('authenticates a user and returns session info', function () {
+    $user = User::create([
+        'username'  => 'testserver',
+        'name'      => 'Test Server',
+        'email'     => 'test@example.test',
+        'password'  => Hash::make('secret'),
+        'is_active' => true,
+    ]);
+    $user->assignRole('SERVER');
+
+    $response = $this->postJson('/api/v1/auth/login', [
+        'username' => 'testserver',
+        'password' => 'secret',
+        'language' => 'en-US',
+    ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.user.displayName', 'Test Server')
+        ->assertJsonPath('data.user.roles.0', 'SERVER');
+});
+
+it('rejects invalid credentials', function () {
+    $response = $this->postJson('/api/v1/auth/login', [
+        'username' => 'nobody',
+        'password' => 'wrong',
+    ]);
+
+    $response->assertStatus(401)
+        ->assertJsonPath('success', false)
+        ->assertJsonPath('error.code', 'UNAUTHENTICATED');
+});
+
+it('returns current user on me endpoint when authenticated', function () {
+    $user = makeUser('SERVER');
+
+    $response = $this->actingAs($user)->getJson('/api/v1/auth/me');
+
+    $response->assertStatus(200)
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.displayName', $user->name);
+});
+
+it('rejects me endpoint when unauthenticated', function () {
+    $response = $this->getJson('/api/v1/auth/me');
+
+    $response->assertStatus(401)
+        ->assertJsonPath('error.code', 'UNAUTHENTICATED');
+});
+
+it('logs out and invalidates session', function () {
+    $user = makeUser('SERVER');
+
+    $this->actingAs($user)->postJson('/api/v1/auth/logout')
+        ->assertStatus(200)
+        ->assertJsonPath('success', true);
+
+    $this->getJson('/api/v1/auth/me')
+        ->assertStatus(401);
+});

--- a/tests/Feature/ApiBillingGroupTest.php
+++ b/tests/Feature/ApiBillingGroupTest.php
@@ -1,0 +1,168 @@
+<?php
+
+use App\Domain\Floor\BillingGroupService;
+use App\Domain\Floor\OccupancyService;
+use App\Models\BillingGroup;
+use App\Models\BillingStatus;
+use App\Models\MenuItem;
+use App\Models\Row;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->session = bootScenario();
+    $this->server  = makeUser('SERVER');
+    $this->cashier = makeUser('CASHIER');
+    $this->group   = app(BillingGroupService::class)->open($this->session, $this->server);
+    $this->zone    = app(OccupancyService::class)->assignZone(
+        $this->group, Row::first(), 1, 2, $this->server
+    );
+});
+
+it('creates a billing group via api', function () {
+    $response = $this->actingAs($this->server)->postJson('/api/v1/billing-groups', [
+        'statusCode' => 'WAITING',
+        'coverCount' => 4,
+        'notes'      => 'API test group',
+        'zones'      => [
+            [
+                'rowId'                   => Row::first()->id,
+                'startSeatPairSequence'   => 3,
+                'endSeatPairSequence'     => 4,
+                'deliveryMode'            => 'CENTER',
+            ],
+        ],
+    ]);
+
+    $response->assertStatus(201)
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.statusCode', 'WAITING')
+        ->assertJsonPath('data.coverCount', 4);
+});
+
+it('returns a billing group with zones and totals', function () {
+    $response = $this->actingAs($this->server)->getJson("/api/v1/billing-groups/{$this->group->id}");
+
+    $response->assertStatus(200)
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.billingGroupId', $this->group->id)
+        ->assertJsonPath('data.displayCode', $this->group->display_code);
+});
+
+it('updates billing group status and notes', function () {
+    $response = $this->actingAs($this->server)->patchJson("/api/v1/billing-groups/{$this->group->id}", [
+        'versionNumber' => 1,
+        'statusCode'    => 'CHECK_REQUESTED',
+        'notes'         => 'Updated via API',
+    ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.statusCode', 'CHECK_REQUESTED');
+});
+
+it('rejects update with stale version number', function () {
+    $this->group->update(['version_number' => 5]);
+
+    $response = $this->actingAs($this->server)->patchJson("/api/v1/billing-groups/{$this->group->id}", [
+        'versionNumber' => 1,
+        'notes'         => 'Should fail',
+    ]);
+
+    $response->assertStatus(409)
+        ->assertJsonPath('error.code', 'VERSION_CONFLICT');
+});
+
+it('rejects update on closed group', function () {
+    $this->group->update(['is_closed' => true, 'closed_at' => now()]);
+
+    $response = $this->actingAs($this->server)->patchJson("/api/v1/billing-groups/{$this->group->id}", [
+        'notes' => 'Should fail',
+    ]);
+
+    $response->assertStatus(409)
+        ->assertJsonPath('error.code', 'GROUP_CLOSED');
+});
+
+it('adds zones to an existing billing group', function () {
+    $response = $this->actingAs($this->server)->postJson("/api/v1/billing-groups/{$this->group->id}/zones", [
+        'zones' => [
+            [
+                'rowId'                 => Row::first()->id,
+                'startSeatPairSequence' => 5,
+                'endSeatPairSequence'   => 6,
+            ],
+        ],
+    ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('success', true);
+});
+
+it('rejects overlapping zones', function () {
+    $response = $this->actingAs($this->server)->postJson("/api/v1/billing-groups/{$this->group->id}/zones", [
+        'zones' => [
+            [
+                'rowId'                 => Row::first()->id,
+                'startSeatPairSequence' => 1,
+                'endSeatPairSequence'   => 2,
+            ],
+        ],
+    ]);
+
+    $response->assertStatus(409)
+        ->assertJsonPath('error.code', 'ZONE_OVERLAP');
+});
+
+it('returns orders for a billing group', function () {
+    $kitchenItem = MenuItem::where('display_name', 'Bacalhau')->first();
+    app(\App\Domain\Orders\OrderService::class)->submit(
+        $this->group, $this->server,
+        [['menu_item_id' => $kitchenItem->id, 'quantity' => 1]],
+        $this->zone
+    );
+
+    $response = $this->actingAs($this->server)->getJson("/api/v1/billing-groups/{$this->group->id}/orders");
+
+    $response->assertStatus(200)
+        ->assertJsonPath('success', true)
+        ->assertJsonCount(1, 'data');
+});
+
+it('returns bill summary for a billing group', function () {
+    $response = $this->actingAs($this->cashier)->getJson("/api/v1/billing-groups/{$this->group->id}/bill-summary");
+
+    $response->assertStatus(200)
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.billingGroupId', $this->group->id);
+});
+
+it('reopens a closed billing group', function () {
+    app(\App\Domain\Billing\BillingService::class)->recordPayment(
+        $this->group, $this->cashier, 1000.00, 'Numerário'
+    );
+
+    $this->group->refresh();
+    expect($this->group->is_closed)->toBeTrue();
+
+    $response = $this->actingAs($this->cashier)->postJson("/api/v1/billing-groups/{$this->group->id}/reopen", [
+        'reason' => 'Guest returned',
+    ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.isClosed', false);
+});
+
+it('enforces role permissions on billing group endpoints', function () {
+    $admin = makeUser('ADMIN');
+
+    // Admin can create
+    $this->actingAs($admin)->postJson('/api/v1/billing-groups', [
+        'statusCode' => 'ACTIVE',
+    ])->assertStatus(201);
+
+    // Cashier cannot create
+    $this->actingAs($this->cashier)->postJson('/api/v1/billing-groups', [
+        'statusCode' => 'ACTIVE',
+    ])->assertStatus(403);
+});

--- a/tests/Feature/ApiOrderTest.php
+++ b/tests/Feature/ApiOrderTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Domain\Floor\BillingGroupService;
+use App\Domain\Floor\OccupancyService;
+use App\Models\MenuItem;
+use App\Models\Row;
+
+beforeEach(function () {
+    $this->session = bootScenario();
+    $this->server  = makeUser('SERVER');
+    $this->group   = app(BillingGroupService::class)->open($this->session, $this->server);
+    $this->zone    = app(OccupancyService::class)->assignZone(
+        $this->group, Row::first(), 1, 2, $this->server
+    );
+});
+
+it('creates an order via api', function () {
+    $kitchenItem = MenuItem::where('display_name', 'Bacalhau')->first();
+
+    $response = $this->actingAs($this->server)->postJson('/api/v1/orders', [
+        'billingGroupId' => $this->group->id,
+        'occupiedZoneId' => $this->zone->id,
+        'notes'          => 'API order',
+        'items'          => [
+            [
+                'menuItemId' => $kitchenItem->id,
+                'quantity'   => 3,
+            ],
+        ],
+    ]);
+
+    $response->assertStatus(201)
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.submissionStatus', 'SUBMITTED')
+        ->assertJsonCount(1, 'data.items');
+});
+
+it('returns an order by id', function () {
+    $kitchenItem = MenuItem::where('display_name', 'Bacalhau')->first();
+    $header = app(\App\Domain\Orders\OrderService::class)->submit(
+        $this->group, $this->server,
+        [['menu_item_id' => $kitchenItem->id, 'quantity' => 2]],
+        $this->zone
+    );
+
+    $response = $this->actingAs($this->server)->getJson("/api/v1/orders/{$header->id}");
+
+    $response->assertStatus(200)
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.orderHeaderId', $header->id);
+});
+
+it('rejects order on closed billing group', function () {
+    $this->group->update(['is_closed' => true, 'closed_at' => now()]);
+    $kitchenItem = MenuItem::where('display_name', 'Bacalhau')->first();
+
+    $response = $this->actingAs($this->server)->postJson('/api/v1/orders', [
+        'billingGroupId' => $this->group->id,
+        'items'          => [
+            ['menuItemId' => $kitchenItem->id, 'quantity' => 1],
+        ],
+    ]);
+
+    $response->assertStatus(409)
+        ->assertJsonPath('error.code', 'GROUP_CLOSED');
+});
+
+it('voids order items via api', function () {
+    $kitchenItem = MenuItem::where('display_name', 'Bacalhau')->first();
+    $header = app(\App\Domain\Orders\OrderService::class)->submit(
+        $this->group, $this->server,
+        [['menu_item_id' => $kitchenItem->id, 'quantity' => 2]],
+        $this->zone
+    );
+
+    $item = $header->items->first();
+
+    $response = $this->actingAs($this->server)->postJson("/api/v1/orders/{$header->id}/void-items", [
+        'items' => [
+            [
+                'orderItemId' => $item->id,
+                'reason'      => 'Wrong item ordered',
+            ],
+        ],
+    ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('success', true)
+        ->assertJsonCount(1, 'data.affectedItems');
+});
+
+it('enforces role permissions on order endpoints', function () {
+    $cashier = makeUser('CASHIER');
+    $kitchenItem = MenuItem::where('display_name', 'Bacalhau')->first();
+
+    // Cashier cannot create orders
+    $this->actingAs($cashier)->postJson('/api/v1/orders', [
+        'billingGroupId' => $this->group->id,
+        'items'          => [
+            ['menuItemId' => $kitchenItem->id, 'quantity' => 1],
+        ],
+    ])->assertStatus(403);
+});

--- a/tests/Feature/ApiPaymentTest.php
+++ b/tests/Feature/ApiPaymentTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Domain\Billing\BillingService;
+use App\Domain\Floor\BillingGroupService;
+use App\Domain\Floor\OccupancyService;
+use App\Models\MenuItem;
+use App\Models\Row;
+
+beforeEach(function () {
+    $this->session = bootScenario();
+    $this->server  = makeUser('SERVER');
+    $this->cashier = makeUser('CASHIER');
+    $this->group   = app(BillingGroupService::class)->open($this->session, $this->server);
+    $this->zone    = app(OccupancyService::class)->assignZone(
+        $this->group, Row::first(), 1, 2, $this->server
+    );
+
+    $kitchenItem = MenuItem::where('display_name', 'Bacalhau')->first();
+    app(\App\Domain\Orders\OrderService::class)->submit(
+        $this->group, $this->server,
+        [['menu_item_id' => $kitchenItem->id, 'quantity' => 2]],
+        $this->zone
+    );
+});
+
+it('records a partial payment via api', function () {
+    $response = $this->actingAs($this->cashier)->postJson('/api/v1/payments', [
+        'billingGroupId' => $this->group->id,
+        'amount'         => '10.00',
+        'paymentLabel'   => 'Cash',
+        'notes'          => 'Partial payment',
+    ]);
+
+    $response->assertStatus(201)
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.amount', '10.00');
+
+    $this->group->refresh();
+    expect($this->group->status?->code)->toBe('PARTIALLY_PAID');
+});
+
+it('records a full payment and closes the group', function () {
+    $response = $this->actingAs($this->cashier)->postJson('/api/v1/payments', [
+        'billingGroupId' => $this->group->id,
+        'amount'         => '36.00',
+        'paymentLabel'   => 'Cash',
+    ]);
+
+    $response->assertStatus(201)
+        ->assertJsonPath('success', true);
+
+    $this->group->refresh();
+    expect($this->group->is_closed)->toBeTrue();
+});
+
+it('rejects payment on closed group', function () {
+    $this->group->update(['is_closed' => true, 'closed_at' => now()]);
+
+    $response = $this->actingAs($this->cashier)->postJson('/api/v1/payments', [
+        'billingGroupId' => $this->group->id,
+        'amount'         => '10.00',
+        'paymentLabel'   => 'Cash',
+    ]);
+
+    $response->assertStatus(409)
+        ->assertJsonPath('error.code', 'GROUP_CLOSED');
+});
+
+it('rejects zero or negative payment amount', function () {
+    $response = $this->actingAs($this->cashier)->postJson('/api/v1/payments', [
+        'billingGroupId' => $this->group->id,
+        'amount'         => '0',
+        'paymentLabel'   => 'Cash',
+    ]);
+
+    $response->assertStatus(422);
+});
+
+it('enforces role permissions on payment endpoints', function () {
+    // Server cannot record payments
+    $this->actingAs($this->server)->postJson('/api/v1/payments', [
+        'billingGroupId' => $this->group->id,
+        'amount'         => '10.00',
+        'paymentLabel'   => 'Cash',
+    ])->assertStatus(403);
+});

--- a/tests/Feature/RolePolicyTest.php
+++ b/tests/Feature/RolePolicyTest.php
@@ -25,12 +25,12 @@ it('inactive users cannot access the panel even with role', function () {
     expect($admin->refresh()->canAccessPanel(\Filament\Facades\Filament::getPanel('admin')))->toBeFalse();
 });
 
-it('servers have submit_order permission and cashiers do not', function () {
-    expect(makeUser('SERVER')->hasPermissionTo('submit_order'))->toBeTrue();
-    expect(makeUser('CASHIER')->hasPermissionTo('submit_order'))->toBeFalse();
+it('servers have order.create permission and cashiers do not', function () {
+    expect(makeUser('SERVER')->hasPermissionTo('order.create'))->toBeTrue();
+    expect(makeUser('CASHIER')->hasPermissionTo('order.create'))->toBeFalse();
 });
 
-it('cashiers have record_payment permission and servers do not', function () {
-    expect(makeUser('CASHIER')->hasPermissionTo('record_payment'))->toBeTrue();
-    expect(makeUser('SERVER')->hasPermissionTo('record_payment'))->toBeFalse();
+it('cashiers have payment.record permission and servers do not', function () {
+    expect(makeUser('CASHIER')->hasPermissionTo('payment.record'))->toBeTrue();
+    expect(makeUser('SERVER')->hasPermissionTo('payment.record'))->toBeFalse();
 });

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -24,8 +24,14 @@ use Spatie\Permission\PermissionRegistrar;
 function bootScenario(): ServiceSession
 {
     foreach ([
-        'view_floor', 'create_billing_group', 'submit_order', 'reopen_billing_group',
-        'view_audit', 'generate_internal_bill', 'reprint_bill', 'record_payment', 'retry_print_job',
+        'floor.view', 'floor.open_billing_group', 'floor.assign_zone', 'floor.release_zone',
+        'billing_group.view', 'billing_group.set_status', 'billing_group.reopen',
+        'order.create', 'order.void_item',
+        'production_ticket.view', 'production_ticket.reprint',
+        'billing_document.create', 'billing_document.reprint',
+        'payment.record', 'payment.void',
+        'print_job.view', 'print_job.retry',
+        'audit.view',
     ] as $perm) {
         Permission::findOrCreate($perm);
     }
@@ -33,8 +39,20 @@ function bootScenario(): ServiceSession
         Role::findOrCreate($r);
     }
     Role::findByName('ADMIN')->syncPermissions(Permission::all());
-    Role::findByName('SERVER')->syncPermissions(['view_floor', 'create_billing_group', 'submit_order', 'reopen_billing_group', 'view_audit']);
-    Role::findByName('CASHIER')->syncPermissions(['view_floor', 'generate_internal_bill', 'reprint_bill', 'record_payment', 'retry_print_job', 'view_audit']);
+    Role::findByName('SERVER')->syncPermissions([
+        'floor.view', 'floor.open_billing_group', 'floor.assign_zone', 'floor.release_zone',
+        'billing_group.view', 'billing_group.set_status', 'billing_group.reopen',
+        'order.create', 'order.void_item',
+        'production_ticket.view',
+        'audit.view',
+    ]);
+    Role::findByName('CASHIER')->syncPermissions([
+        'billing_group.view', 'billing_group.reopen',
+        'billing_document.create', 'billing_document.reprint',
+        'payment.record', 'payment.void',
+        'print_job.view', 'print_job.retry',
+        'audit.view',
+    ]);
     app(PermissionRegistrar::class)->forgetCachedPermissions();
 
     foreach ([


### PR DESCRIPTION
## Summary

Implements the entire MVP `/api/v1` REST API contract as documented in `api-contract.md`.

### Authentication
- `POST /api/v1/auth/login`
- `POST /api/v1/auth/logout`
- `GET /api/v1/auth/me`

### Floor & Occupancy
- `GET /api/v1/sessions/current`
- `GET /api/v1/floor`
- `POST /api/v1/billing-groups`
- `GET /api/v1/billing-groups/{id}`
- `PATCH /api/v1/billing-groups/{id}`
- `POST /api/v1/billing-groups/{id}/zones`
- `PATCH /api/v1/occupied-zones/{id}`

### Orders
- `POST /api/v1/orders`
- `GET /api/v1/orders/{id}`
- `POST /api/v1/orders/{id}/void-items`

### Production Tickets
- `GET /api/v1/production-tickets/{id}`
- `POST /api/v1/production-tickets/{id}/reprint`

### Billing & Checkout
- `GET /api/v1/billing-groups/{id}/bill-summary`
- `POST /api/v1/billing-documents`
- `POST /api/v1/billing-documents/{id}/reprint`
- `POST /api/v1/payments`
- `POST /api/v1/billing-groups/{id}/reopen`

### Event Log
- `GET /api/v1/event-log`

### Admin Configuration
- `GET/POST/PATCH` for venues, sections, rows, seats, seat-pairs, billing-statuses, menu-categories, menu-items, printers, printer-routes, users, roles, translations, accounting-exports

### Requirements
- Consistent response envelope (`{success, data, meta}` / `{success, error}`)
- Common error codes implemented
- Role-based authorization at endpoint level
- Optimistic locking via `versionNumber` on billing group updates
- Tests for auth, billing-groups, orders, and payments endpoints

Closes #1