### PR TITLE
feat: implement light/dark theme support (#11)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@ Allowed focus:
 - Keep layouts simple and task-focused.
 - Use server-driven interactions with Livewire wherever practical.
 - Use Filament primarily for admin/configuration surfaces, not for core service-floor UX.
+- **All UI components, screens, and design changes must support both light and dark themes from inception.** Configure Tailwind `dark:` variants and test both modes before considering UI work complete.
 
 ### Screen intent
 

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -33,6 +33,14 @@ class UserResource extends Resource
             Forms\Components\Select::make('preferred_language_code')
                 ->options(['pt-PT' => 'Português (PT)', 'en-US' => 'English (US)'])
                 ->default('pt-PT')->required(),
+            Forms\Components\Select::make('theme')
+                ->options([
+                    User::THEME_LIGHT  => 'Claro',
+                    User::THEME_DARK   => 'Escuro',
+                    User::THEME_SYSTEM => 'Sistema',
+                ])
+                ->default(User::THEME_SYSTEM)
+                ->required(),
             Forms\Components\Toggle::make('is_active')->default(true),
             Forms\Components\TextInput::make('password')
                 ->password()

--- a/app/Http/Controllers/Api/Admin/UserController.php
+++ b/app/Http/Controllers/Api/Admin/UserController.php
@@ -20,6 +20,7 @@ class UserController extends ApiController
             'displayName'       => $u->name,
             'email'             => $u->email,
             'preferredLanguage' => $u->preferred_language_code,
+            'theme'             => $u->theme,
             'isActive'          => $u->is_active,
             'roles'             => $u->roles->pluck('name')->values()->all(),
         ])->all());
@@ -57,6 +58,7 @@ class UserController extends ApiController
             'displayName'       => ['nullable', 'string', 'max:100'],
             'email'             => ['nullable', 'email', 'max:255'],
             'preferredLanguage' => ['nullable', 'string', 'max:10'],
+            'theme'             => ['nullable', 'string', 'in:light,dark,system'],
             'isActive'          => ['nullable', 'boolean'],
         ]);
 
@@ -64,6 +66,7 @@ class UserController extends ApiController
         if (array_key_exists('displayName', $validated))       $update['name'] = $validated['displayName'];
         if (array_key_exists('email', $validated))             $update['email'] = $validated['email'];
         if (array_key_exists('preferredLanguage', $validated)) $update['preferred_language_code'] = $validated['preferredLanguage'];
+        if (array_key_exists('theme', $validated))             $update['theme'] = $validated['theme'];
         if (array_key_exists('isActive', $validated))          $update['is_active'] = $validated['isActive'];
 
         $user->update($update);

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -44,6 +44,7 @@ class AuthController extends ApiController
                 'displayName'       => $user->name,
                 'roles'             => $user->roles->pluck('name')->values()->all(),
                 'preferredLanguage' => $user->preferred_language_code,
+                'theme'             => $user->theme,
             ],
             'session' => [
                 'token'     => $request->session()->getId(),
@@ -69,6 +70,7 @@ class AuthController extends ApiController
             'displayName'       => $user->name,
             'roles'             => $user->roles->pluck('name')->values()->all(),
             'preferredLanguage' => $user->preferred_language_code,
+            'theme'             => $user->theme,
             'permissions'       => $user->permissions->pluck('name')->values()->all(),
         ]);
     }

--- a/app/Http/Middleware/ApplyUserTheme.php
+++ b/app/Http/Middleware/ApplyUserTheme.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ApplyUserTheme
+{
+    /**
+     * Inject a small inline script that applies the correct theme class
+     * to <html> before paint, avoiding flash of unstyled content.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        if (! $response->isSuccessful()) {
+            return $response;
+        }
+
+        $contentType = $response->headers->get('Content-Type', '');
+        if (! str_contains($contentType, 'text/html')) {
+            return $response;
+        }
+
+        $theme = $this->resolveTheme($request);
+
+        $script = <<<JS
+<script>
+    (function() {
+        var theme = '{$theme}';
+        if (theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            document.documentElement.classList.add('dark');
+        } else {
+            document.documentElement.classList.remove('dark');
+        }
+    })();
+</script>
+JS;
+
+        $content = $response->getContent();
+        if ($content === false) {
+            return $response;
+        }
+
+        // Inject script immediately after <head> to run before paint
+        $content = preg_replace('/(<head[^>]*>)/i', '$1' . $script, $content, 1);
+        $response->setContent($content);
+
+        return $response;
+    }
+
+    private function resolveTheme(Request $request): string
+    {
+        $user = $request->user();
+
+        if ($user && in_array($user->theme, [User::THEME_LIGHT, User::THEME_DARK], true)) {
+            return $user->theme;
+        }
+
+        return User::THEME_SYSTEM;
+    }
+}

--- a/app/Livewire/ThemeToggle.php
+++ b/app/Livewire/ThemeToggle.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+class ThemeToggle extends Component
+{
+    public string $theme = User::THEME_SYSTEM;
+
+    public function mount(): void
+    {
+        $this->theme = Auth::user()?->theme ?? User::THEME_SYSTEM;
+    }
+
+    public function setTheme(string $theme): void
+    {
+        if (! in_array($theme, [User::THEME_LIGHT, User::THEME_DARK, User::THEME_SYSTEM], true)) {
+            return;
+        }
+
+        $this->theme = $theme;
+
+        if ($user = Auth::user()) {
+            $user->update(['theme' => $theme]);
+        }
+
+        // Dispatch a browser event so any inline script can react immediately.
+        $this->dispatch('theme-changed', theme: $theme);
+    }
+
+    public function render()
+    {
+        return view('livewire.theme-toggle');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,12 +19,17 @@ class User extends Authenticatable implements FilamentUser
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable, HasRoles;
 
+    public const THEME_LIGHT  = 'light';
+    public const THEME_DARK   = 'dark';
+    public const THEME_SYSTEM = 'system';
+
     protected $fillable = [
         'name',
         'email',
         'username',
         'password',
         'preferred_language_code',
+        'theme',
         'is_active',
         'last_login_at',
     ];

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use Filament\Enums\ThemeMode;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -10,12 +11,14 @@ use Filament\Pages;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
+use Filament\View\PanelsRenderHook;
 use Filament\Widgets;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 class AdminPanelProvider extends PanelProvider
@@ -46,6 +49,29 @@ class AdminPanelProvider extends PanelProvider
                 Widgets\AccountWidget::class,
                 Widgets\FilamentInfoWidget::class,
             ])
+            ->darkMode()
+            ->renderHook(
+                PanelsRenderHook::GLOBAL_SEARCH_AFTER,
+                fn (): string => Blade::render('@livewire(\'theme-toggle\')'),
+            )
+            ->renderHook(
+                PanelsRenderHook::BODY_START,
+                fn (): string => Blade::render(<<<'BLADE'
+<script>
+    document.addEventListener('livewire:init', () => {
+        Livewire.on('theme-changed', (event) => {
+            var theme = event.theme;
+            if (theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                document.documentElement.classList.add('dark');
+            } else {
+                document.documentElement.classList.remove('dark');
+            }
+        });
+    });
+</script>
+BLADE
+                ),
+            )
             ->middleware([
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -24,6 +24,11 @@ return Application::configure(basePath: dirname(__DIR__))
             \Illuminate\Cookie\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
         ]);
+
+        // Apply light/dark theme to all HTML responses before paint.
+        $middleware->web(append: [
+            \App\Http\Middleware\ApplyUserTheme::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/migrations/2026_04_30_000000_add_theme_to_users_table.php
+++ b/database/migrations/2026_04_30_000000_add_theme_to_users_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->enum('theme', ['light', 'dark', 'system'])->default('system')->after('preferred_language_code');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('theme');
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
     --font-sans: 'Figtree', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 }

--- a/resources/views/filament/pages/billing-group-detail.blade.php
+++ b/resources/views/filament/pages/billing-group-detail.blade.php
@@ -1,16 +1,16 @@
 <x-filament-panels::page>
     <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
         <div class="rounded-lg border bg-white p-4 dark:bg-gray-900">
-            <div class="text-xs text-gray-500">Estado</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400">Estado</div>
             <div class="text-lg font-semibold">{{ $group->status?->display_name ?? $group->status?->code }}</div>
         </div>
         <div class="rounded-lg border bg-white p-4 dark:bg-gray-900">
-            <div class="text-xs text-gray-500">Total a pagar</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400">Total a pagar</div>
             <div class="text-lg font-semibold">{{ number_format($charges, 2, ',', ' ') }} EUR</div>
-            <div class="text-xs text-gray-500">Pago: {{ number_format($paid, 2, ',', ' ') }} EUR</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400">Pago: {{ number_format($paid, 2, ',', ' ') }} EUR</div>
         </div>
         <div class="rounded-lg border bg-white p-4 dark:bg-gray-900">
-            <div class="text-xs text-gray-500">Saldo em aberto</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400">Saldo em aberto</div>
             <div class="text-2xl font-bold {{ $balance > 0 ? 'text-warning-600' : 'text-success-600' }}">
                 {{ number_format($balance, 2, ',', ' ') }} EUR
             </div>
@@ -20,16 +20,16 @@
     <div class="mt-6 rounded-lg border bg-white p-4 dark:bg-gray-900">
         <h3 class="mb-3 text-base font-semibold">Zonas ocupadas</h3>
         @if ($group->occupiedZones->isEmpty())
-            <p class="text-sm text-gray-500">Sem zonas atribuídas.</p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Sem zonas atribuídas.</p>
         @else
-            <ul class="divide-y">
+            <ul class="divide-y dark:divide-gray-700">
                 @foreach ($group->occupiedZones as $zone)
                     <li class="flex items-center justify-between py-2 text-sm">
                         <div>
                             <span class="font-medium">{{ $zone->row?->section?->section_code }} · {{ $zone->rangeLabel() }}</span>
-                            <span class="ml-2 text-xs text-gray-500">Entrega: {{ $zone->defaultDeliveryLabel() }}</span>
+                            <span class="ml-2 text-xs text-gray-500 dark:text-gray-400">Entrega: {{ $zone->defaultDeliveryLabel() }}</span>
                             @if (! $zone->is_open)
-                                <span class="ml-2 rounded-full bg-gray-200 px-2 py-0.5 text-xs">libertada</span>
+                                <span class="ml-2 rounded-full bg-gray-200 px-2 py-0.5 text-xs dark:bg-gray-700">libertada</span>
                             @endif
                         </div>
                         @if ($zone->is_open && ! $group->is_closed)
@@ -50,16 +50,16 @@
     <div class="mt-6 rounded-lg border bg-white p-4 dark:bg-gray-900">
         <h3 class="mb-3 text-base font-semibold">Pedidos</h3>
         @if ($group->orderHeaders->isEmpty())
-            <p class="text-sm text-gray-500">Sem pedidos.</p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Sem pedidos.</p>
         @else
             @foreach ($group->orderHeaders as $header)
-                <div class="mb-3 rounded border p-3">
-                    <div class="mb-1 flex items-center justify-between text-xs text-gray-500">
+                <div class="mb-3 rounded border p-3 dark:border-gray-700">
+                    <div class="mb-1 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
                         <span>Pedido #{{ $header->id }} · {{ $header->ordered_at?->format('H:i') }} · {{ $header->submission_status }}</span>
                     </div>
                     <table class="w-full text-sm">
                         <thead>
-                            <tr class="text-left text-xs uppercase text-gray-500">
+                            <tr class="text-left text-xs uppercase text-gray-500 dark:text-gray-400">
                                 <th class="py-1">Item</th>
                                 <th class="py-1">Qtd</th>
                                 <th class="py-1">Rota</th>
@@ -69,7 +69,7 @@
                         </thead>
                         <tbody>
                             @foreach ($header->items as $item)
-                                <tr class="{{ $item->voided_at ? 'line-through text-gray-400' : '' }}">
+                                <tr class="{{ $item->voided_at ? 'line-through text-gray-400 dark:text-gray-500' : '' }}">
                                     <td class="py-1">{{ $item->menuItem?->display_name }}</td>
                                     <td class="py-1">{{ $item->quantity }}</td>
                                     <td class="py-1">{{ $item->fulfillment_route }}</td>
@@ -88,7 +88,7 @@
         <h3 class="mb-3 text-base font-semibold">Documentos &amp; pagamentos</h3>
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
             <div>
-                <div class="mb-1 text-xs uppercase text-gray-500">Contas impressas</div>
+                <div class="mb-1 text-xs uppercase text-gray-500 dark:text-gray-400">Contas impressas</div>
                 @forelse ($group->billingDocuments as $doc)
                     <div class="text-sm">
                         {{ $doc->document_number }} · {{ $doc->document_type }} ·
@@ -96,18 +96,18 @@
                         @if ($doc->is_reprint) <em>(reimpressão)</em> @endif
                     </div>
                 @empty
-                    <p class="text-sm text-gray-500">Sem contas impressas.</p>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">Sem contas impressas.</p>
                 @endforelse
             </div>
             <div>
-                <div class="mb-1 text-xs uppercase text-gray-500">Pagamentos</div>
+                <div class="mb-1 text-xs uppercase text-gray-500 dark:text-gray-400">Pagamentos</div>
                 @forelse ($group->paymentRecords as $p)
-                    <div class="text-sm {{ $p->is_voided ? 'line-through text-gray-400' : '' }}">
+                    <div class="text-sm {{ $p->is_voided ? 'line-through text-gray-400 dark:text-gray-500' : '' }}">
                         {{ $p->payment_label }} · {{ number_format((float)$p->amount, 2, ',', ' ') }} EUR ·
                         {{ $p->recorded_at?->format('Y-m-d H:i') }}
                     </div>
                 @empty
-                    <p class="text-sm text-gray-500">Sem pagamentos.</p>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">Sem pagamentos.</p>
                 @endforelse
             </div>
         </div>

--- a/resources/views/filament/pages/cashier-checkout.blade.php
+++ b/resources/views/filament/pages/cashier-checkout.blade.php
@@ -1,10 +1,10 @@
 <x-filament-panels::page>
     @if (! $session)
-        <div class="rounded-lg bg-warning-50 p-4 text-warning-900">
+        <div class="rounded-lg bg-warning-50 p-4 text-warning-900 dark:bg-warning-900 dark:text-warning-100">
             Não existe sessão de serviço aberta.
         </div>
     @elseif ($groups->isEmpty())
-        <div class="rounded-lg bg-gray-50 p-4 text-gray-700">Nenhum grupo a apresentar.</div>
+        <div class="rounded-lg bg-gray-50 p-4 text-gray-700 dark:bg-gray-800 dark:text-gray-300">Nenhum grupo a apresentar.</div>
     @else
         <div class="overflow-x-auto rounded-lg border bg-white dark:bg-gray-900">
             <table class="w-full text-sm">
@@ -23,7 +23,7 @@
                     @foreach ($groups as $group)
                         <tr class="border-t {{ $group->is_closed ? 'opacity-60' : '' }}">
                             <td class="px-3 py-2">
-                                <a class="font-semibold text-primary-600 hover:underline"
+                                <a class="font-semibold text-primary-600 hover:underline dark:text-primary-400"
                                    href="{{ \App\Filament\Pages\BillingGroupDetail::getUrl(['record' => $group->id]) }}">
                                     {{ $group->display_code }}
                                 </a>

--- a/resources/views/filament/pages/floor.blade.php
+++ b/resources/views/filament/pages/floor.blade.php
@@ -1,6 +1,6 @@
 <x-filament-panels::page>
     @if (! $session)
-        <div class="rounded-lg bg-warning-50 p-4 text-warning-900">
+        <div class="rounded-lg bg-warning-50 p-4 text-warning-900 dark:bg-warning-900 dark:text-warning-100">
             Não existe nenhuma sessão de serviço aberta. Crie uma sessão em
             <em>Configuração &rarr; Sessões de serviço</em> antes de operar o salão.
         </div>

--- a/resources/views/filament/pages/order-entry.blade.php
+++ b/resources/views/filament/pages/order-entry.blade.php
@@ -2,36 +2,36 @@
     <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
         <div class="lg:col-span-2 space-y-4">
             @foreach ($categories as $category)
-                <div class="rounded-lg border bg-white p-4 dark:bg-gray-900">
-                    <h3 class="mb-2 text-sm font-semibold uppercase text-gray-500">
-                        {{ $category->display_name }} <span class="text-xs">({{ $category->route_type }})</span>
-                    </h3>
-                    <div class="flex flex-wrap gap-2">
-                        @foreach ($category->items as $item)
-                            <button type="button" wire:click="addItem({{ $item->id }})"
-                                class="rounded border border-primary-300 bg-primary-50 px-3 py-2 text-left text-sm hover:bg-primary-100">
-                                <div class="font-medium">{{ $item->display_name }}</div>
-                                <div class="text-xs text-gray-600">{{ number_format((float)$item->unit_price, 2, ',', ' ') }} EUR</div>
-                            </button>
-                        @endforeach
-                    </div>
+            <div class="rounded-lg border bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
+                <h3 class="mb-2 text-sm font-semibold uppercase text-gray-500 dark:text-gray-400">
+                    {{ $category->display_name }} <span class="text-xs">({{ $category->route_type }})</span>
+                </h3>
+                <div class="flex flex-wrap gap-2">
+                    @foreach ($category->items as $item)
+                        <button type="button" wire:click="addItem({{ $item->id }})"
+                            class="rounded border border-primary-300 bg-primary-50 px-3 py-2 text-left text-sm hover:bg-primary-100 dark:border-primary-700 dark:bg-primary-900 dark:hover:bg-primary-800">
+                            <div class="font-medium">{{ $item->display_name }}</div>
+                            <div class="text-xs text-gray-600 dark:text-gray-400">{{ number_format((float)$item->unit_price, 2, ',', ' ') }} EUR</div>
+                        </button>
+                    @endforeach
                 </div>
+            </div>
             @endforeach
         </div>
 
         <div class="space-y-4">
-            <div class="rounded-lg border bg-white p-4 dark:bg-gray-900">
+            <div class="rounded-lg border bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
                 <h3 class="mb-2 text-sm font-semibold">Carrinho</h3>
                 @if (empty($cartDetailed))
-                    <p class="text-sm text-gray-500">Nenhum item adicionado.</p>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">Nenhum item adicionado.</p>
                 @else
                     <table class="w-full text-sm">
                         <tbody>
                             @foreach ($cartDetailed as $line)
-                                <tr class="border-b last:border-0">
+                                <tr class="border-b last:border-0 dark:border-gray-700">
                                     <td class="py-1">
                                         <div class="font-medium">{{ $line['name'] }}</div>
-                                        <div class="text-xs text-gray-500">{{ number_format($line['price'], 2, ',', ' ') }} EUR</div>
+                                        <div class="text-xs text-gray-500 dark:text-gray-400">{{ number_format($line['price'], 2, ',', ' ') }} EUR</div>
                                     </td>
                                     <td class="py-1 text-center">
                                         <button class="px-1" wire:click="changeQty({{ $line['index'] }}, -1)">−</button>
@@ -41,7 +41,7 @@
                                     <td class="py-1 text-right">{{ number_format($line['subtotal'], 2, ',', ' ') }}</td>
                                     <td class="py-1 pl-2">
                                         <button wire:click="removeItem({{ $line['index'] }})"
-                                            class="text-xs text-danger-600">remover</button>
+                                            class="text-xs text-danger-600 dark:text-danger-400">remover</button>
                                     </td>
                                 </tr>
                             @endforeach
@@ -58,9 +58,9 @@
                 @endif
             </div>
 
-            <div class="rounded-lg border bg-white p-4 dark:bg-gray-900">
-                <label class="text-xs font-semibold uppercase text-gray-500">Zona de entrega</label>
-                <select wire:model.live="occupiedZoneId" class="mt-1 w-full rounded border-gray-300 text-sm">
+            <div class="rounded-lg border bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
+                <label class="text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">Zona de entrega</label>
+                <select wire:model.live="occupiedZoneId" class="mt-1 w-full rounded border-gray-300 text-sm dark:border-gray-700 dark:bg-gray-800">
                     <option value="">— sem zona específica —</option>
                     @foreach ($zoneOptions as $id => $label)
                         <option value="{{ $id }}">{{ $label }}</option>
@@ -68,8 +68,8 @@
                 </select>
 
                 @if (! empty($pairOptions))
-                    <label class="mt-3 block text-xs font-semibold uppercase text-gray-500">Par de lugar (opcional)</label>
-                    <select wire:model.live="deliveryPairId" class="mt-1 w-full rounded border-gray-300 text-sm">
+                    <label class="mt-3 block text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">Par de lugar (opcional)</label>
+                    <select wire:model.live="deliveryPairId" class="mt-1 w-full rounded border-gray-300 text-sm dark:border-gray-700 dark:bg-gray-800">
                         <option value="">— centro da zona —</option>
                         @foreach ($pairOptions as $id => $label)
                             <option value="{{ $id }}">{{ $label }}</option>
@@ -77,9 +77,9 @@
                     </select>
                 @endif
 
-                <label class="mt-3 block text-xs font-semibold uppercase text-gray-500">Notas</label>
+                <label class="mt-3 block text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">Notas</label>
                 <textarea wire:model.defer="notes" rows="2"
-                    class="mt-1 w-full rounded border-gray-300 text-sm"></textarea>
+                    class="mt-1 w-full rounded border-gray-300 text-sm dark:border-gray-700 dark:bg-gray-800"></textarea>
             </div>
 
             <x-filament::button wire:click="submitOrder" color="primary" icon="heroicon-o-paper-airplane" class="w-full">

--- a/resources/views/livewire/theme-toggle.blade.php
+++ b/resources/views/livewire/theme-toggle.blade.php
@@ -1,0 +1,32 @@
+<div class="flex items-center gap-2">
+    <button
+        type="button"
+        wire:click="setTheme('light')"
+        title="Claro"
+        class="rounded p-1.5 transition {{ $theme === 'light' ? 'bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300' : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800' }}"
+    >
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+        </svg>
+    </button>
+    <button
+        type="button"
+        wire:click="setTheme('dark')"
+        title="Escuro"
+        class="rounded p-1.5 transition {{ $theme === 'dark' ? 'bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300' : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800' }}"
+    >
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" />
+        </svg>
+    </button>
+    <button
+        type="button"
+        wire:click="setTheme('system')"
+        title="Sistema"
+        class="rounded p-1.5 transition {{ $theme === 'system' ? 'bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300' : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800' }}"
+    >
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0V12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 12V5.25" />
+        </svg>
+    </button>
+</div>

--- a/tests/Feature/ThemeSupportTest.php
+++ b/tests/Feature/ThemeSupportTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+beforeEach(function () {
+    $this->session = bootScenario();
+});
+
+it('defaults user theme to system', function () {
+    $user = User::create([
+        'username'  => 'themetest',
+        'name'      => 'Theme Test',
+        'email'     => 'theme@example.test',
+        'password'  => Hash::make('secret'),
+        'is_active' => true,
+    ]);
+
+    expect($user->fresh()->theme)->toBe(User::THEME_SYSTEM);
+});
+
+it('allows setting theme to light or dark', function () {
+    $user = makeUser('SERVER');
+
+    $user->update(['theme' => User::THEME_DARK]);
+    expect($user->fresh()->theme)->toBe(User::THEME_DARK);
+
+    $user->update(['theme' => User::THEME_LIGHT]);
+    expect($user->fresh()->theme)->toBe(User::THEME_LIGHT);
+});
+
+it('returns theme in login response', function () {
+    $user = User::create([
+        'username'  => 'themetest',
+        'name'      => 'Theme Test',
+        'email'     => 'theme@example.test',
+        'password'  => Hash::make('secret'),
+        'is_active' => true,
+        'theme'     => User::THEME_DARK,
+    ]);
+    $user->assignRole('SERVER');
+
+    $response = $this->postJson('/api/v1/auth/login', [
+        'username' => 'themetest',
+        'password' => 'secret',
+    ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.user.theme', 'dark');
+});
+
+it('returns theme in me response', function () {
+    $user = makeUser('SERVER');
+    $user->update(['theme' => User::THEME_LIGHT]);
+
+    $response = $this->actingAs($user)->getJson('/api/v1/auth/me');
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.theme', 'light');
+});
+
+it('allows admin to update user theme via api', function () {
+    $admin = makeUser('ADMIN');
+    $user = makeUser('SERVER');
+
+    $response = $this->actingAs($admin)->patchJson("/api/v1/admin/users/{$user->id}", [
+        'theme' => User::THEME_DARK,
+    ]);
+
+    $response->assertStatus(200);
+    expect($user->fresh()->theme)->toBe(User::THEME_DARK);
+});
+
+it('rejects invalid theme values via api', function () {
+    $admin = makeUser('ADMIN');
+    $user = makeUser('SERVER');
+
+    $response = $this->actingAs($admin)->patchJson("/api/v1/admin/users/{$user->id}", [
+        'theme' => 'invalid',
+    ]);
+
+    $response->assertStatus(422);
+});
+
+it('injects theme script for authenticated user', function () {
+    $user = makeUser('SERVER');
+    $user->update(['theme' => User::THEME_DARK]);
+
+    $response = $this->actingAs($user)->get('/');
+
+    $response->assertStatus(200);
+    $response->assertSee("var theme = 'dark';", false);
+});
+
+it('injects system theme script when user theme is system', function () {
+    $user = makeUser('SERVER');
+    $user->update(['theme' => User::THEME_SYSTEM]);
+
+    $response = $this->actingAs($user)->get('/');
+
+    $response->assertStatus(200);
+    $response->assertSee("var theme = 'system';", false);
+});
+
+it('includes theme in admin users list', function () {
+    $admin = makeUser('ADMIN');
+    $user = makeUser('SERVER');
+    $user->update(['theme' => User::THEME_DARK]);
+
+    $response = $this->actingAs($admin)->getJson('/api/v1/admin/users');
+
+    $response->assertStatus(200);
+    $data = $response->json('data');
+    $found = collect($data)->first(fn ($u) => $u['userId'] === $user->id);
+    expect($found)->not->toBeNull();
+    expect($found['theme'])->toBe('dark');
+});


### PR DESCRIPTION
## Summary

Implements full light/dark theme support for the application as requested in #11.

### Changes

- **User model & migration**: Added `theme` enum column (`light`/`dark`/`system`, default `system`) to the `users` table.
- **Tailwind CSS v4**: Configured `@custom-variant dark` for class-based dark mode.
- **Middleware**: Created `ApplyUserTheme` middleware that injects an inline script immediately after `<head>` to apply the `dark` class before first paint, eliminating FOUC. Defaults to `prefers-color-scheme` when the user preference is `system`.
- **Filament panel**: Enabled dark mode in `AdminPanelProvider` and added a `ThemeToggle` Livewire component to the top toolbar. A client-side listener syncs the DOM class instantly when the user switches theme.
- **Admin UI**: Added theme selection to the `UserResource` form.
- **API**: Updated `AuthController` and `UserController` to return and persist `theme`, with validation (`in:light,dark,system`).
- **Blade views**: Audited all core Filament pages (floor, order-entry, billing-group-detail, cashier-checkout) and added missing `dark:` variants for backgrounds, borders, text, and dividers.
- **Documentation**: Updated `AGENTS.md` to mandate dual-theme support for all future UI work.
- **Tests**: Added `ThemeSupportTest` with 9 assertions covering defaults, API read/write, middleware script injection, and admin list inclusion.

### Verification

- All 57 tests pass.
- No scope drift introduced.

Closes #11