### PR TITLE
fix: Docker build failures - PHP 8.4, directory creation, CI validation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,13 +24,16 @@ docs/
 # CI
 .github/
 
-# Storage (runtime data, not needed in image)
+# Storage & bootstrap cache (runtime data, not needed in image)
 storage/logs/
 storage/framework/cache/
 storage/framework/sessions/
 storage/framework/views/
 storage/framework/testing/
 storage/debugbar/
+
+# Bootstrap cache files (generated at runtime by artisan optimize)
+bootstrap/cache/*.php
 
 # IDE
 .idea/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,17 +57,35 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push app image
+      - name: Build app image (load for validation)
         uses: docker/build-push-action@v6
+        id: build
         with:
           context: .
           file: docker/app/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          push: false
+          load: true
+          tags: serveo-app:ci
           labels: ${{ steps.meta.outputs.labels }}
           no-cache: ${{ github.event_name == 'workflow_dispatch' && inputs.no_cache }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Validate app image
+        run: |
+          echo "Verifying image structure..."
+          docker run --rm --entrypoint php serveo-app:ci -v
+          docker run --rm --entrypoint php serveo-app:ci -m | grep -qE 'pdo_pgsql|redis|gd|intl|bcmath|pcntl' && echo "Required extensions OK"
+          docker run --rm --entrypoint ls serveo-app:ci /var/www/html/vendor/autoload.php && echo "Composer autoload OK"
+          echo "Image validation passed."
+
+      - name: Push app image
+        if: github.event_name != 'pull_request'
+        run: |
+          for tag in ${{ steps.meta.outputs.tags }}; do
+            docker tag serveo-app:ci "$tag"
+            docker push "$tag"
+          done
 
   build-web:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,11 +73,38 @@ jobs:
 
       - name: Validate app image
         run: |
-          echo "Verifying image structure..."
+          echo "==========  1. PHP version  =========="
           docker run --rm --entrypoint php serveo-app:ci -v
-          docker run --rm --entrypoint php serveo-app:ci -m | grep -qE 'pdo_pgsql|redis|gd|intl|bcmath|pcntl' && echo "Required extensions OK"
-          docker run --rm --entrypoint ls serveo-app:ci /var/www/html/vendor/autoload.php && echo "Composer autoload OK"
-          echo "Image validation passed."
+
+          echo "==========  2. Required extensions  =========="
+          docker run --rm --entrypoint php serveo-app:ci -m | grep -qE 'pdo_pgsql|redis|gd|intl|bcmath|pcntl' && echo "  All required extensions present"
+
+          echo "==========  3. Composer autoload  =========="
+          docker run --rm --entrypoint ls serveo-app:ci /var/www/html/vendor/autoload.php && echo "  autoload.php exists"
+
+          echo "==========  4. Laravel boots  =========="
+          docker run --rm \
+            -e APP_KEY=base64:dummykeyfordockerbuildonly12345= \
+            -e DB_CONNECTION=sqlite \
+            -e DB_DATABASE=:memory: \
+            -e CACHE_STORE=array \
+            -e SESSION_DRIVER=array \
+            --entrypoint php serveo-app:ci artisan inspire --no-interaction && echo "  Artisan booted successfully"
+
+          echo "==========  5. .git/ not leaked  =========="
+          docker run --rm --entrypoint sh serveo-app:ci -c 'test ! -d /var/www/html/.git && echo "  .git/ excluded from image"'
+
+          echo "==========  6. No dev packages  =========="
+          docker run --rm --entrypoint sh serveo-app:ci -c 'test ! -d /var/www/html/vendor/phpunit && test ! -d /var/www/html/vendor/laravel/dusk && echo "  No dev-only packages present"'
+
+          echo "==========  7. Entrypoint syntax  =========="
+          docker run --rm --entrypoint sh serveo-app:ci -n /entrypoint.sh && echo "  entrypoint.sh syntax valid"
+
+          echo "==========  8. File permissions  =========="
+          docker run --rm --entrypoint stat serveo-app:ci -c '%U:%G' /var/www/html | grep -q 'serveo:serveo' && echo "  /var/www/html owned by serveo:serveo"
+
+          echo ""
+          echo "==========  All 8 validation checks passed  =========="
 
       - name: Push app image
         if: github.event_name != 'pull_request'

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,9 @@
     },
     "extra": {
         "laravel": {
-            "dont-discover": []
+            "dont-discover": [
+            "laravel/dusk"
+        ]
         }
     },
     "config": {

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-fpm-bookworm
+FROM php:8.4-fpm-bookworm
 
 ARG WWWUSER=1000
 ARG WWWGROUP=1000
@@ -32,12 +32,18 @@ WORKDIR /var/www/html
 # Copy app as ROOT so composer can write composer.lock
 COPY . /var/www/html
 
-# Install dependencies
-RUN composer install --no-dev --no-interaction --optimize-autoloader --no-progress
+# Create storage/cache directories needed at runtime
+RUN mkdir -p storage/framework/cache \
+             storage/framework/sessions \
+             storage/framework/views \
+             storage/logs \
+             bootstrap/cache
 
-# Set up directories and permissions
-RUN mkdir -p storage/framework/{cache,sessions,views} bootstrap/cache \
-    && chown -R serveo:serveo /var/www/html
+# Install dependencies (skip post-autoload scripts — entrypoint handles optimization at runtime)
+RUN composer install --no-dev --no-interaction --no-progress --no-scripts --optimize-autoloader
+
+# Set final permissions
+RUN chown -R serveo:serveo /var/www/html
 
 # Entrypoint: runs migrate + optimize at runtime with real env vars, then starts php-fpm
 COPY --chmod=755 docker/app/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
## Summary

Follow-up fixes to issue #47 (Docker build). Local build testing revealed several issues that weren't caught by code review alone.

## Changes

### `docker/app/Dockerfile`
- **PHP 8.3 → 8.4**: `composer.lock` has Symfony v8.0.8 requiring PHP >=8.4
- **Fixed mkdir**: Brace expansion `{cache,sessions,views}` doesn't work in `sh` — replaced with individual `mkdir` calls
- **`--no-scripts`**: Skipping post-autoload-dump scripts avoids `php artisan package:discover` failures during build (entrypoint handles optimization at runtime)
- **Reordered steps**: Directory creation before `composer install`

### `.dockerignore`
- Added `bootstrap/cache/*.php` exclusion — prevents stale locally-generated `packages.php`/`services.php` from being copied into the image (they reference dev-only providers like `DuskServiceProvider`)

### `composer.json`
- Added `laravel/dusk` to `dont-discover` — prevents production auto-discovery of dev-only package

### `.github/workflows/docker.yml`
- **Added image validation step**: Verifies PHP version, required extensions, and autoloader before pushing
- **Restructured**: Build → load locally → validate → push (prevents broken images from reaching registry)
- All existing features preserved (caching, PR triggers, conditional no-cache)

## Local verification

- ✅ App image builds successfully
- ✅ Web image builds successfully  
- ✅ PHP 8.4.21 with all required extensions
- ✅ Composer autoloader present and valid
- ✅ No `DuskServiceProvider` or other dev-only references in image

## CI verification

This PR triggers the `pull_request` workflow which validates (but does not push) the image.